### PR TITLE
Refactor architecture with Setting abstraction and clearer naming

### DIFF
--- a/ARCHITECTURE.ts
+++ b/ARCHITECTURE.ts
@@ -351,7 +351,6 @@ export const ShotCompositionSchema = z.object({
     .optional(),
   overrides: z
     .object({
-      setting: SettingPartialSchema.optional(),
       lighting: LightingPartialSchema.optional(),
       color: ColorScriptPartialSchema.optional(),
       mood: MoodPartialSchema.optional(),
@@ -381,7 +380,8 @@ export const StoryBeatSchema = z.object({
     pose_and_props: z.string(),            // pose description and any props
     focus: z.enum(['primary', 'secondary', 'background']) // character's importance in shot
   })).default([]),                         // characters present in this beat
-  shot_composition: ShotCompositionSchema, // complete visual direction for this shot (includes setting override)
+  setting: SettingPartialSchema.optional(), // per-beat setting override (biome, location, time, etc.)
+  shot_composition: ShotCompositionSchema, // complete visual direction for this shot
 });
 
 export type StoryBeat = z.infer<typeof StoryBeatSchema>;


### PR DESCRIPTION
## Summary
- Create standalone `SettingSchema` for shared location/time/biome descriptors
- Rename schemas for clarity throughout the architecture
- Add `Book` schema as the final rendered output
- Update complete agent pipeline with clearer data flow

## Key Renamings

### Data Structures
- **`StoryDraft` → `Manuscript`**: Text-only story (no visuals yet)
- **`StoryPage` → `ManuscriptPage`**: Individual manuscript pages
- **`PageTreatment` → `StoryPage`**: Complete page with visual beats
- **`ArtBible` → `Story`**: Complete story ready for rendering (manuscript + visual direction)

### Agents
- **`ArtDirectorAgent` → `DirectorAgent`**: More concise, outputs "Story"

## New Features

**Setting Abstraction:**
- Created `SettingSchema` with `biome`, `location`, `time_of_day`, `season`, `landmarks`, `diegetic_lights`
- Used globally in `VisualStyleGuide.setting`
- Can be overridden per-shot in `ShotComposition.overrides.setting`
- Removed redundant `time` and `location` fields from `StoryBeatSchema`

**Book Schema:**
- New `BookSchema` represents final rendered book
- Contains `BookPage[]` with manuscript text + rendered images
- Final pipeline output: `Book` instead of `RenderedImage[]`

## Updated Pipeline

**Before:**
```
BookBuilderAgent → AuthorAgent → ArtDirectorAgent → IllustratorAgent
(StoryBrief)      (StoryDraft)   (ArtBible)        (RenderedImage[])
```

**After:**
```
BookBuilderAgent → AuthorAgent → DirectorAgent → IllustratorAgent
(StoryBrief)      (Manuscript)   (Story)        (Book)
```

## Benefits
- **Clearer naming**: "Story" now represents a complete story ready to render, not just an art bible
- **DRY setting management**: Setting defined once, reused globally and per-shot
- **Better separation**: Manuscript = text only, Story = text + visuals, Book = final output
- **Type safety**: All agent types updated with correct input/output schemas

## Test Plan
- [ ] Verify all schemas compile without TypeScript errors
- [ ] Confirm examples match updated schemas
- [ ] Check that Setting can be used globally and overridden per-shot
- [ ] Validate complete pipeline types: `StoryBrief → Manuscript → Story → Book`

🤖 Generated with [Claude Code](https://claude.com/claude-code)