### PR TITLE
Improve test coverage for cli/output module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ npm-debug.log*
 
 # Story output
 output/
+
+# Test coverage
+coverage/

--- a/src/cli/output/display.test.ts
+++ b/src/cli/output/display.test.ts
@@ -1,0 +1,384 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { displayBrief, displayManuscript, displayStory, displayBook } from './display';
+import type { StoryBrief, Manuscript, Story, Book } from '../../core/schemas';
+
+// Mock console.log to capture output
+const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+beforeEach(() => {
+  consoleSpy.mockClear();
+});
+
+afterEach(() => {
+  consoleSpy.mockClear();
+});
+
+describe('displayBrief', () => {
+  const minimalBrief: StoryBrief = {
+    title: 'The Magic Garden',
+    storyArc: 'A rabbit discovers a hidden garden',
+    setting: 'A cottage in the woods',
+    ageRange: { min: 4, max: 8 },
+    pageCount: 24,
+    characters: [
+      { name: 'Luna', description: 'A curious rabbit', traits: [], notes: [] },
+    ],
+    interests: [],
+    customInstructions: [],
+  };
+
+  it('displays brief title', () => {
+    displayBrief(minimalBrief);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('The Magic Garden');
+  });
+
+  it('displays story arc', () => {
+    displayBrief(minimalBrief);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('A rabbit discovers a hidden garden');
+  });
+
+  it('displays age range', () => {
+    displayBrief(minimalBrief);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('4-8 years');
+  });
+
+  it('displays characters', () => {
+    displayBrief(minimalBrief);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('Luna');
+    expect(output).toContain('A curious rabbit');
+  });
+
+  it('displays optional tone when present', () => {
+    const briefWithTone = { ...minimalBrief, tone: 'Whimsical' };
+    displayBrief(briefWithTone);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('Whimsical');
+  });
+
+  it('displays optional moral when present', () => {
+    const briefWithMoral = { ...minimalBrief, moral: 'Be curious' };
+    displayBrief(briefWithMoral);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('Be curious');
+  });
+
+  it('displays character role when present', () => {
+    const briefWithRole: StoryBrief = {
+      ...minimalBrief,
+      characters: [
+        { name: 'Luna', description: 'A curious rabbit', role: 'protagonist', traits: [], notes: [] },
+      ],
+    };
+    displayBrief(briefWithRole);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('protagonist');
+  });
+});
+
+describe('displayManuscript', () => {
+  const minimalBlurb = {
+    brief: {
+      title: 'Test',
+      storyArc: 'Test arc',
+      setting: 'Test setting',
+      ageRange: { min: 4, max: 8 },
+      pageCount: 8,
+      characters: [{ name: 'Test', description: 'Test char', traits: [], notes: [] }],
+      interests: [],
+      customInstructions: [],
+    },
+    plotBeats: [],
+    allowCreativeLiberty: true,
+  };
+
+  const minimalManuscript: Manuscript = {
+    blurb: minimalBlurb,
+    title: 'The Magic Garden',
+    logline: 'A rabbit finds wonder in unexpected places',
+    theme: 'Curiosity and discovery',
+    setting: 'A hidden garden',
+    ageRange: { min: 4, max: 8 },
+    pageCount: 8,
+    characters: [{ name: 'Luna', description: 'A curious rabbit', traits: [], notes: [] }],
+    pages: [
+      { summary: 'Luna finds the gate', text: 'Luna found an old gate.', imageConcept: 'Rabbit at gate' },
+      { summary: 'Luna enters garden', text: 'She pushed it open.', imageConcept: 'Garden entrance' },
+      { summary: 'Luna meets friend', text: 'A butterfly appeared.', imageConcept: 'Butterfly meeting' },
+      { summary: 'They explore', text: 'Together they explored.', imageConcept: 'Exploration' },
+      { summary: 'Discovery', text: 'They found a pond.', imageConcept: 'Pond scene' },
+      { summary: 'Playing', text: 'They played all day.', imageConcept: 'Playing' },
+      { summary: 'Sunset', text: 'The sun began to set.', imageConcept: 'Sunset' },
+      { summary: 'Home', text: 'Luna went home happy.', imageConcept: 'Happy ending' },
+    ],
+  };
+
+  it('displays manuscript title', () => {
+    displayManuscript(minimalManuscript);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('The Magic Garden');
+  });
+
+  it('displays logline', () => {
+    displayManuscript(minimalManuscript);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('A rabbit finds wonder in unexpected places');
+  });
+
+  it('displays first 5 page summaries', () => {
+    displayManuscript(minimalManuscript);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('Luna finds the gate');
+    expect(output).toContain('Luna enters garden');
+    expect(output).toContain('Luna meets friend');
+    expect(output).toContain('They explore');
+    expect(output).toContain('Discovery');
+  });
+
+  it('shows remaining page count when more than 5 pages', () => {
+    displayManuscript(minimalManuscript);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('3 more pages');
+  });
+
+  it('does not show remaining count for 5 or fewer pages', () => {
+    const shortManuscript: Manuscript = {
+      ...minimalManuscript,
+      pageCount: 5,
+      pages: minimalManuscript.pages.slice(0, 5),
+    };
+    displayManuscript(shortManuscript);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).not.toContain('more pages');
+  });
+});
+
+describe('displayStory', () => {
+  const minimalStory: Story = {
+    storyTitle: 'The Magic Garden',
+    ageRange: { min: 4, max: 8 },
+    characters: {
+      luna: { name: 'Luna', description: 'A curious rabbit', traits: [], notes: [] },
+    },
+    manuscript: {
+      meta: {
+        title: 'The Magic Garden',
+        logline: 'A rabbit finds wonder',
+        theme: 'Curiosity',
+        setting: 'Garden',
+      },
+      pages: {
+        '1': { summary: 'Intro', text: 'Luna found a gate.', imageConcept: 'Gate' },
+      },
+    },
+    style: {
+      art_direction: {
+        genre: ['fantasy', 'childrens'],
+        medium: ['digital illustration'],
+        technique: ['soft shading'],
+      },
+      setting: {
+        landmarks: [],
+        diegetic_lights: [],
+      },
+    },
+    pages: [
+      {
+        pageNumber: 1,
+        beats: [
+          {
+            order: 1,
+            purpose: 'setup',
+            summary: 'Luna discovers the garden gate',
+            emotion: 'curious',
+            characters: [],
+            shot: {
+              size: 'wide',
+              angle: 'eye_level',
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  it('displays story title', () => {
+    displayStory(minimalStory);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('The Magic Garden');
+  });
+
+  it('displays page count', () => {
+    displayStory(minimalStory);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('Pages:');
+  });
+
+  it('displays total beats', () => {
+    displayStory(minimalStory);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('Total Beats:');
+  });
+
+  it('displays art direction genres', () => {
+    displayStory(minimalStory);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('fantasy');
+    expect(output).toContain('childrens');
+  });
+
+  it('displays first page beats', () => {
+    displayStory(minimalStory);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('Luna discovers the garden gate');
+    expect(output).toContain('wide');
+    expect(output).toContain('eye_level');
+  });
+});
+
+describe('displayBook', () => {
+  const minimalBook: Book = {
+    storyTitle: 'The Magic Garden',
+    ageRange: { min: 4, max: 8 },
+    pages: [
+      {
+        pageNumber: 1,
+        text: 'Luna found an old garden gate covered in vines.',
+        images: [
+          {
+            id: 'img-1',
+            pageNumber: 1,
+            url: 'https://example.com/img1.png',
+            width: 1024,
+            height: 768,
+            mimeType: 'image/png',
+          },
+        ],
+      },
+      {
+        pageNumber: 2,
+        text: 'She pushed it open and stepped inside.',
+        images: [
+          {
+            id: 'img-2',
+            pageNumber: 2,
+            url: 'https://example.com/img2.png',
+            width: 1024,
+            height: 768,
+            mimeType: 'image/png',
+          },
+        ],
+      },
+      {
+        pageNumber: 3,
+        text: 'The garden was full of colorful flowers.',
+        images: [
+          {
+            id: 'img-3',
+            pageNumber: 3,
+            url: 'https://example.com/img3.png',
+            width: 1024,
+            height: 768,
+            mimeType: 'image/png',
+          },
+        ],
+      },
+      {
+        pageNumber: 4,
+        text: 'A butterfly landed on her nose.',
+        images: [
+          {
+            id: 'img-4',
+            pageNumber: 4,
+            url: 'https://example.com/img4.png',
+            width: 1024,
+            height: 768,
+            mimeType: 'image/png',
+          },
+        ],
+      },
+    ],
+  };
+
+  it('displays book title', () => {
+    displayBook(minimalBook);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('The Magic Garden');
+  });
+
+  it('displays age range', () => {
+    displayBook(minimalBook);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('4-8 years');
+  });
+
+  it('displays total images', () => {
+    displayBook(minimalBook);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('Total Images:');
+  });
+
+  it('displays first 3 page previews', () => {
+    displayBook(minimalBook);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('Page 1');
+    expect(output).toContain('Page 2');
+    expect(output).toContain('Page 3');
+    expect(output).toContain('Luna found an old garden gate');
+  });
+
+  it('shows remaining page count when more than 3 pages', () => {
+    displayBook(minimalBook);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('1 more pages');
+  });
+
+  it('truncates long text in preview', () => {
+    const bookWithLongText: Book = {
+      ...minimalBook,
+      pages: [
+        {
+          pageNumber: 1,
+          text: 'A'.repeat(100),
+          images: minimalBook.pages[0]!.images,
+        },
+      ],
+    };
+    displayBook(bookWithLongText);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('...');
+  });
+
+  it('displays completion message', () => {
+    displayBook(minimalBook);
+
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('Book generation complete!');
+  });
+});

--- a/src/cli/output/progress.test.ts
+++ b/src/cli/output/progress.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { createSpinner, formatStep, progressBar } from './progress';
+
+describe('createSpinner', () => {
+  it('returns a spinner instance with dots spinner', () => {
+    const spinner = createSpinner();
+
+    expect(spinner).toBeDefined();
+    expect(typeof spinner.start).toBe('function');
+    expect(typeof spinner.stop).toBe('function');
+    expect(typeof spinner.succeed).toBe('function');
+    expect(typeof spinner.fail).toBe('function');
+  });
+});
+
+describe('formatStep', () => {
+  it('formats known step name', () => {
+    expect(formatStep('book-builder')).toBe('Extracting story brief...');
+  });
+
+  it('formats completed known step', () => {
+    expect(formatStep('book-builder', true)).toBe('Extracting story brief ✓');
+  });
+
+  it('formats author step', () => {
+    expect(formatStep('author')).toBe('Writing manuscript...');
+    expect(formatStep('author', true)).toBe('Writing manuscript ✓');
+  });
+
+  it('formats director step', () => {
+    expect(formatStep('director')).toBe('Creating visual direction...');
+    expect(formatStep('director', true)).toBe('Creating visual direction ✓');
+  });
+
+  it('formats illustrator step', () => {
+    expect(formatStep('illustrator')).toBe('Rendering illustrations...');
+    expect(formatStep('illustrator', true)).toBe('Rendering illustrations ✓');
+  });
+
+  it('uses step name as fallback for unknown steps', () => {
+    expect(formatStep('unknown-step')).toBe('unknown-step...');
+    expect(formatStep('unknown-step', true)).toBe('unknown-step ✓');
+  });
+});
+
+describe('progressBar', () => {
+  it('shows empty bar at 0%', () => {
+    const result = progressBar(0, 10, 10);
+    expect(result).toBe('[░░░░░░░░░░] 0%');
+  });
+
+  it('shows full bar at 100%', () => {
+    const result = progressBar(10, 10, 10);
+    expect(result).toBe('[██████████] 100%');
+  });
+
+  it('shows half bar at 50%', () => {
+    const result = progressBar(5, 10, 10);
+    expect(result).toBe('[█████░░░░░] 50%');
+  });
+
+  it('rounds percentage correctly', () => {
+    const result = progressBar(1, 3, 9);
+    expect(result).toBe('[███░░░░░░] 33%');
+  });
+
+  it('uses default width of 30', () => {
+    const result = progressBar(5, 10);
+    expect(result).toContain('[');
+    expect(result).toContain(']');
+    expect(result).toContain('50%');
+    // Width 30 = 15 filled, 15 empty
+    const barContent = result.slice(1, result.indexOf(']'));
+    expect(barContent.length).toBe(30);
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive tests for display functions
- Complete progress.ts test coverage
- Add coverage/ to .gitignore

## Changes
- **New**: `src/cli/output/display.test.ts` - 24 tests for displayBrief, displayManuscript, displayStory, displayBook
- **Edit**: `src/cli/output/progress.test.ts` - Add createSpinner test
- **Edit**: `.gitignore` - Exclude coverage/ folder

## Coverage Improvement
| Module | Before | After |
|--------|--------|-------|
| cli/output | 11.42% | **100%** |
| cli/utils | 100% | 100% |
| core/schemas | 100% | 100% |
| **Overall** | 23.86% | **41.47%** |

## Test plan
- [x] All 96 tests pass (`npm run test:run`)
- [x] TypeScript compiles without errors (`npm run typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)