### PR TITLE
Add page rendering with Replicate image generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "commander": "^12.0.0",
         "dotenv": "^17.2.3",
         "ora": "^8.0.0",
+        "replicate": "^1.4.0",
         "zod": "^3.23.0"
       },
       "bin": {
@@ -1481,6 +1482,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/ai": {
       "version": "4.3.19",
       "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
@@ -1563,6 +1577,52 @@
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
         "js-tokens": "^9.0.1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/chai": {
@@ -1766,6 +1826,26 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
@@ -1866,6 +1946,27 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -2202,6 +2303,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
@@ -2210,6 +2321,38 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/replicate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/replicate/-/replicate-1.4.0.tgz",
+      "integrity": "sha512-1ufKejfUVz/azy+5TnzQP7U1+MHVWZ6psnQ06az8byUUnRhT+DZ/MvewzB1NQYBVMgNKR7xPDtTwlcP5nv/5+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "git": ">=2.11.0",
+        "node": ">=18.0.0",
+        "npm": ">=7.19.0",
+        "yarn": ">=1.7.0"
+      },
+      "optionalDependencies": {
+        "readable-stream": ">=4.0.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -2279,6 +2422,27 @@
         "@rollup/rollup-win32-x64-msvc": "4.53.3",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -2358,6 +2522,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "commander": "^12.0.0",
     "dotenv": "^17.2.3",
     "ora": "^8.0.0",
+    "replicate": "^1.4.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/src/cli/commands/render.ts
+++ b/src/cli/commands/render.ts
@@ -1,38 +1,97 @@
 import { Command } from 'commander';
-import { runBook } from '../../core/pipeline';
+import * as fs from 'fs/promises';
+import * as path from 'path';
 import { StorySchema } from '../../core/schemas';
 import { createSpinner } from '../output/progress';
 import { displayBook } from '../output/display';
 import { loadOutputManager, isStoryFolder, createOutputManager } from '../utils/output';
+import { illustratorAgent, type IllustratorConfig } from '../../core/agents';
+import { downloadImage } from '../../core/services/image-generation';
+
+interface RenderOptions {
+  output?: string;
+  mock?: boolean;
+  model?: 'flux-schnell' | 'sdxl' | 'nano-banana-pro';
+  download?: boolean;
+}
 
 export const renderCommand = new Command('render')
   .description('Render a Book from a Story (generate images)')
   .argument('<story-file>', 'Path to Story JSON file')
   .option('-o, --output <path>', 'Output directory for book files')
-  .action(async (storyFile: string, options: { output?: string }) => {
+  .option('-m, --mock', 'Use mock images instead of real generation')
+  .option('--model <model>', 'Image model: flux-schnell (default), sdxl, nano-banana-pro')
+  .option('-d, --download', 'Download images to local assets folder')
+  .action(async (storyFile: string, options: RenderOptions) => {
     const spinner = createSpinner();
 
     try {
       // Load and validate story
       spinner.start('Loading story...');
-      const fs = await import('fs/promises');
       const storyJson = await fs.readFile(storyFile, 'utf-8');
       const story = StorySchema.parse(JSON.parse(storyJson));
       spinner.succeed('Story loaded');
 
+      // Count total beats for progress
+      const totalBeats = story.pages.reduce((sum, p) => sum + p.beats.length, 0);
+      let completedBeats = 0;
+
+      // Configure illustrator
+      const config: IllustratorConfig = {
+        mock: options.mock ?? false,
+        model: options.model ?? 'flux-schnell',
+        onImageGenerated: (pageNumber, beatOrder, _url) => {
+          completedBeats++;
+          spinner.text = `Rendering illustrations... (${completedBeats}/${totalBeats}) Page ${pageNumber}, Beat ${beatOrder}`;
+        },
+      };
+
       // Generate book
-      spinner.start('Rendering illustrations...');
-      const book = await runBook(story);
-      spinner.succeed('Illustrations complete');
+      spinner.start(`Rendering illustrations... (0/${totalBeats})`);
+      const book = await illustratorAgent(story, config);
+      spinner.succeed(`Rendered ${totalBeats} illustrations`);
+
+      // Set up output manager
+      const outputManager = options.output
+        ? await createOutputManager(book.storyTitle, options.output)
+        : await isStoryFolder(storyFile)
+          ? await loadOutputManager(storyFile)
+          : await createOutputManager(book.storyTitle);
+
+      // Download images if requested
+      if (options.download && !options.mock) {
+        spinner.start('Downloading images...');
+        let downloadedCount = 0;
+
+        for (const page of book.pages) {
+          for (const image of page.images) {
+            try {
+              const imageBuffer = await downloadImage(image.url);
+              const filename = `${image.id}.png`;
+              const imagePath = path.join(outputManager.folder, 'assets', filename);
+              await fs.writeFile(imagePath, imageBuffer);
+
+              // Update the image URL to local path
+              image.url = `assets/${filename}`;
+              downloadedCount++;
+              spinner.text = `Downloading images... (${downloadedCount}/${totalBeats})`;
+            } catch (err) {
+              console.warn(`\nWarning: Failed to download image ${image.id}: ${err}`);
+            }
+          }
+        }
+        spinner.succeed(`Downloaded ${downloadedCount} images`);
+      }
+
+      // Save book
+      await outputManager.saveBook(book);
 
       displayBook(book);
-
-      // Save to story folder (detect existing or create new)
-      const outputManager = await isStoryFolder(storyFile)
-        ? await loadOutputManager(storyFile)
-        : await createOutputManager(book.storyTitle);
-      await outputManager.saveBook(book);
       console.log(`\nBook saved to: ${outputManager.folder}/book.json`);
+
+      if (options.download && !options.mock) {
+        console.log(`Images saved to: ${outputManager.folder}/assets/`);
+      }
     } catch (error) {
       spinner.fail('Failed to render book');
       console.error(error);

--- a/src/core/agents/illustrator.ts
+++ b/src/core/agents/illustrator.ts
@@ -1,44 +1,105 @@
 import type { Story, Book, BookPage, RenderedImage } from '../schemas';
 import type { IllustratorAgent } from './index';
+import { generateImage, type GenerateImageOptions } from '../services/image-generation';
+import { buildBeatPrompt } from '../services/prompt-builder';
+
+/**
+ * Configuration for the illustrator agent
+ */
+export interface IllustratorConfig {
+  /** Image generation model to use */
+  model?: GenerateImageOptions['model'];
+  /** Image width in pixels */
+  width?: number;
+  /** Image height in pixels */
+  height?: number;
+  /** Use mock data instead of real generation (for testing) */
+  mock?: boolean;
+  /** Callback for progress updates */
+  onImageGenerated?: (pageNumber: number, beatOrder: number, imageUrl: string) => void;
+}
+
+const DEFAULT_CONFIG: IllustratorConfig = {
+  model: 'flux-schnell',
+  width: 1024,
+  height: 768, // 4:3 aspect ratio for picture books
+  mock: false,
+};
 
 /**
  * IllustratorAgent: Takes a Story and produces a rendered Book
  *
- * This agent orchestrates image generation for each beat in the story.
- * The actual image generation would integrate with services like:
- * - Replicate (SDXL, Flux)
- * - OpenAI DALL-E
- * - Midjourney API
- * - ComfyUI
- *
- * For now, this is a placeholder that returns mock data.
+ * Orchestrates image generation for each beat in the story using:
+ * - Replicate API with configurable models (Flux, SDXL, Nano Banana Pro)
+ * - Prompt builder to convert story data into image prompts
  */
-export const illustratorAgent: IllustratorAgent = async (story: Story): Promise<Book> => {
+export const illustratorAgent: IllustratorAgent = async (
+  story: Story,
+  config: IllustratorConfig = {}
+): Promise<Book> => {
+  const { model, width, height, mock, onImageGenerated } = {
+    ...DEFAULT_CONFIG,
+    ...config,
+  };
+
   const pages: BookPage[] = [];
 
   for (const storyPage of story.pages) {
     const images: RenderedImage[] = [];
 
     for (const beat of storyPage.beats) {
-      // TODO: Generate actual image from beat + style
-      // const prompt = buildPromptFromBeat(beat, story.style);
-      // const imageUrl = await generateImage(prompt);
+      let imageUrl: string;
+      let imageWidth: number;
+      let imageHeight: number;
+
+      if (mock) {
+        // Mock mode for testing
+        imageUrl = `https://placeholder.com/images/page${storyPage.pageNumber}_beat${beat.order}.png`;
+        imageWidth = width ?? 1024;
+        imageHeight = height ?? 768;
+      } else {
+        // Build prompt from beat data
+        const pageText = story.manuscript.pages[String(storyPage.pageNumber)]?.text;
+        const { prompt, negativePrompt } = buildBeatPrompt(
+          beat,
+          story.style,
+          story.characters,
+          pageText
+        );
+
+        // Generate image
+        const result = await generateImage({
+          prompt,
+          negativePrompt,
+          width,
+          height,
+          model,
+        });
+
+        imageUrl = result.url;
+        imageWidth = result.width;
+        imageHeight = result.height;
+      }
 
       const image: RenderedImage = {
         id: `img_page${storyPage.pageNumber}_beat${beat.order}`,
         pageNumber: storyPage.pageNumber,
         beatOrder: beat.order,
-        url: `https://placeholder.com/images/page${storyPage.pageNumber}_beat${beat.order}.png`, // placeholder
-        width: 2048,
-        height: 1536,
+        url: imageUrl,
+        width: imageWidth,
+        height: imageHeight,
         mimeType: 'image/png',
         meta: {
           prompt: beat.summary,
           style: story.style.art_direction.genre,
+          model: mock ? 'mock' : model,
         },
       };
 
       images.push(image);
+
+      // Notify progress
+      onImageGenerated?.(storyPage.pageNumber, beat.order, imageUrl);
     }
 
     // Get text from the manuscript using the page number
@@ -58,6 +119,16 @@ export const illustratorAgent: IllustratorAgent = async (story: Story): Promise<
     meta: {
       createdAt: new Date().toISOString(),
       version: '1.0',
+      model: mock ? 'mock' : model,
     },
   };
+};
+
+/**
+ * Create an illustrator agent with custom configuration
+ */
+export const createIllustratorAgent = (
+  config: IllustratorConfig
+): IllustratorAgent => {
+  return (story: Story) => illustratorAgent(story, config);
 };

--- a/src/core/agents/index.ts
+++ b/src/core/agents/index.ts
@@ -1,4 +1,5 @@
 import type { StoryBrief, StoryBlurb, Manuscript, Story, Book } from '../schemas';
+import type { IllustratorConfig } from './illustrator';
 
 /**
  * Generic agent type: async function from Input to Output
@@ -10,7 +11,7 @@ export type Agent<Input, Output> = (input: Input) => Promise<Output>;
  */
 export type AuthorAgent = Agent<StoryBlurb, Manuscript>;
 export type DirectorAgent = Agent<Manuscript, Story>;
-export type IllustratorAgent = Agent<Story, Book>;
+export type IllustratorAgent = (story: Story, config?: IllustratorConfig) => Promise<Book>;
 
 /**
  * Progress callback for pipeline steps
@@ -20,7 +21,7 @@ export type OnStepProgress = (step: string, status: 'start' | 'complete' | 'erro
 // Re-export agents
 export { authorAgent } from './author';
 export { directorAgent } from './director';
-export { illustratorAgent } from './illustrator';
+export { illustratorAgent, createIllustratorAgent, type IllustratorConfig } from './illustrator';
 
 // Chat intake agents (StoryBrief)
 export { interpreterAgent } from './interpreter';

--- a/src/core/services/image-generation.test.ts
+++ b/src/core/services/image-generation.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  generateImage,
+  downloadImage,
+  MODEL_CONFIGS,
+  _resetClient,
+  _setClient,
+} from './image-generation';
+import type Replicate from 'replicate';
+
+describe('generateImage', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, REPLICATE_API_TOKEN: 'test-token' };
+    _resetClient();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    _resetClient();
+    vi.clearAllMocks();
+  });
+
+  it('throws error when REPLICATE_API_TOKEN is not set', async () => {
+    delete process.env.REPLICATE_API_TOKEN;
+
+    await expect(generateImage({ prompt: 'test' })).rejects.toThrow(
+      'REPLICATE_API_TOKEN environment variable is required'
+    );
+  });
+
+  it('uses flux-schnell as default model', async () => {
+    const mockRun = vi.fn().mockResolvedValue(['https://example.com/image.png']);
+    const mockClient = { run: mockRun } as unknown as Replicate;
+    _setClient(mockClient);
+
+    await generateImage({ prompt: 'test prompt' });
+
+    expect(mockRun).toHaveBeenCalledWith(
+      'black-forest-labs/flux-schnell',
+      expect.any(Object)
+    );
+  });
+
+  it('handles array output format', async () => {
+    const mockRun = vi.fn().mockResolvedValue(['https://example.com/image.png']);
+    const mockClient = { run: mockRun } as unknown as Replicate;
+    _setClient(mockClient);
+
+    const result = await generateImage({ prompt: 'test' });
+
+    expect(result.url).toBe('https://example.com/image.png');
+  });
+
+  it('handles string output format', async () => {
+    const mockRun = vi.fn().mockResolvedValue('https://example.com/single.png');
+    const mockClient = { run: mockRun } as unknown as Replicate;
+    _setClient(mockClient);
+
+    const result = await generateImage({ prompt: 'test' });
+
+    expect(result.url).toBe('https://example.com/single.png');
+  });
+
+  it('handles FileOutput object format', async () => {
+    const mockFileOutput = {
+      url: () => 'https://example.com/file-output.png',
+    };
+    const mockRun = vi.fn().mockResolvedValue([mockFileOutput]);
+    const mockClient = { run: mockRun } as unknown as Replicate;
+    _setClient(mockClient);
+
+    const result = await generateImage({ prompt: 'test' });
+
+    expect(result.url).toBe('https://example.com/file-output.png');
+  });
+
+  it('throws on unexpected output format', async () => {
+    const mockRun = vi.fn().mockResolvedValue({ unexpected: 'format' });
+    const mockClient = { run: mockRun } as unknown as Replicate;
+    _setClient(mockClient);
+
+    await expect(generateImage({ prompt: 'test' })).rejects.toThrow(
+      'Unexpected output format from model'
+    );
+  });
+
+  it('throws on empty array output', async () => {
+    const mockRun = vi.fn().mockResolvedValue([]);
+    const mockClient = { run: mockRun } as unknown as Replicate;
+    _setClient(mockClient);
+
+    await expect(generateImage({ prompt: 'test' })).rejects.toThrow(
+      'Unexpected output format from model'
+    );
+  });
+
+  it('uses custom dimensions when provided', async () => {
+    const mockRun = vi.fn().mockResolvedValue(['https://example.com/image.png']);
+    const mockClient = { run: mockRun } as unknown as Replicate;
+    _setClient(mockClient);
+
+    const result = await generateImage({
+      prompt: 'test',
+      width: 512,
+      height: 768,
+    });
+
+    expect(result.width).toBe(512);
+    expect(result.height).toBe(768);
+    expect(mockRun).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        input: expect.objectContaining({
+          width: 512,
+          height: 768,
+        }),
+      })
+    );
+  });
+
+  it('uses default dimensions when not provided', async () => {
+    const mockRun = vi.fn().mockResolvedValue(['https://example.com/image.png']);
+    const mockClient = { run: mockRun } as unknown as Replicate;
+    _setClient(mockClient);
+
+    const result = await generateImage({ prompt: 'test' });
+
+    expect(result.width).toBe(1024);
+    expect(result.height).toBe(1024);
+  });
+
+  it('includes negative prompt when provided', async () => {
+    const mockRun = vi.fn().mockResolvedValue(['https://example.com/image.png']);
+    const mockClient = { run: mockRun } as unknown as Replicate;
+    _setClient(mockClient);
+
+    await generateImage({
+      prompt: 'test',
+      negativePrompt: 'blurry, low quality',
+    });
+
+    expect(mockRun).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        input: expect.objectContaining({
+          negative_prompt: 'blurry, low quality',
+        }),
+      })
+    );
+  });
+
+  it('omits negative prompt when not provided', async () => {
+    const mockRun = vi.fn().mockResolvedValue(['https://example.com/image.png']);
+    const mockClient = { run: mockRun } as unknown as Replicate;
+    _setClient(mockClient);
+
+    await generateImage({ prompt: 'test' });
+
+    const callArgs = mockRun.mock.calls[0]?.[1] as { input: Record<string, unknown> } | undefined;
+    expect(callArgs?.input.negative_prompt).toBeUndefined();
+  });
+
+  it('uses sdxl model when specified', async () => {
+    const mockRun = vi.fn().mockResolvedValue(['https://example.com/image.png']);
+    const mockClient = { run: mockRun } as unknown as Replicate;
+    _setClient(mockClient);
+
+    await generateImage({ prompt: 'test', model: 'sdxl' });
+
+    expect(mockRun).toHaveBeenCalledWith(
+      expect.stringContaining('stability-ai/sdxl'),
+      expect.any(Object)
+    );
+  });
+
+  it('uses nano-banana-pro model when specified', async () => {
+    const mockRun = vi.fn().mockResolvedValue(['https://example.com/image.png']);
+    const mockClient = { run: mockRun } as unknown as Replicate;
+    _setClient(mockClient);
+
+    await generateImage({ prompt: 'test', model: 'nano-banana-pro' });
+
+    expect(mockRun).toHaveBeenCalledWith(
+      'google/nano-banana-pro',
+      expect.any(Object)
+    );
+  });
+
+  it('adds flux-specific options for flux-schnell model', async () => {
+    const mockRun = vi.fn().mockResolvedValue(['https://example.com/image.png']);
+    const mockClient = { run: mockRun } as unknown as Replicate;
+    _setClient(mockClient);
+
+    await generateImage({ prompt: 'test', model: 'flux-schnell' });
+
+    expect(mockRun).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        input: expect.objectContaining({
+          num_outputs: 1,
+          aspect_ratio: '4:3',
+          output_format: 'png',
+          output_quality: 90,
+        }),
+      })
+    );
+  });
+});
+
+describe('downloadImage', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('downloads image and returns buffer', async () => {
+    const mockImageData = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG magic bytes
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(mockImageData.buffer),
+    });
+
+    const result = await downloadImage('https://example.com/image.png');
+
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result[0]).toBe(0x89);
+    expect(result[1]).toBe(0x50);
+  });
+
+  it('throws error when download fails', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      statusText: 'Not Found',
+    });
+
+    await expect(downloadImage('https://example.com/404.png')).rejects.toThrow(
+      'Failed to download image: Not Found'
+    );
+  });
+
+  it('calls fetch with the correct URL', async () => {
+    const mockImageData = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(mockImageData.buffer),
+    });
+
+    await downloadImage('https://example.com/test-image.png');
+
+    expect(global.fetch).toHaveBeenCalledWith('https://example.com/test-image.png');
+  });
+});
+
+describe('MODEL_CONFIGS', () => {
+  it('has correct config for flux-schnell', () => {
+    expect(MODEL_CONFIGS['flux-schnell'].identifier).toBe('black-forest-labs/flux-schnell');
+    expect(MODEL_CONFIGS['flux-schnell'].defaultWidth).toBe(1024);
+    expect(MODEL_CONFIGS['flux-schnell'].defaultHeight).toBe(1024);
+  });
+
+  it('has correct config for sdxl', () => {
+    expect(MODEL_CONFIGS['sdxl'].identifier).toContain('stability-ai/sdxl');
+  });
+
+  it('has correct config for nano-banana-pro', () => {
+    expect(MODEL_CONFIGS['nano-banana-pro'].identifier).toBe('google/nano-banana-pro');
+  });
+});

--- a/src/core/services/image-generation.ts
+++ b/src/core/services/image-generation.ts
@@ -1,0 +1,145 @@
+import Replicate from 'replicate';
+
+/**
+ * Image generation service using Replicate API
+ *
+ * Supports multiple models:
+ * - google/nano-banana-pro: Google's Gemini 3 Pro Image model (default)
+ * - black-forest-labs/flux-schnell: Fast, high-quality image generation
+ * - stability-ai/sdxl: Stable Diffusion XL
+ */
+
+export interface GenerateImageOptions {
+  prompt: string;
+  negativePrompt?: string;
+  width?: number;
+  height?: number;
+  model?: 'nano-banana-pro' | 'flux-schnell' | 'sdxl';
+}
+
+export interface GeneratedImage {
+  url: string;
+  width: number;
+  height: number;
+}
+
+export const MODEL_CONFIGS = {
+  'nano-banana-pro': {
+    identifier: 'google/nano-banana-pro',
+    defaultWidth: 1024,
+    defaultHeight: 1024,
+  },
+  'flux-schnell': {
+    identifier: 'black-forest-labs/flux-schnell',
+    defaultWidth: 1024,
+    defaultHeight: 1024,
+  },
+  'sdxl': {
+    identifier: 'stability-ai/sdxl:8beff3369e81422112d93b89ca01426147de542cd4684c244b673b105188fe5f',
+    defaultWidth: 1024,
+    defaultHeight: 1024,
+  },
+} as const;
+
+let replicateClient: Replicate | null = null;
+
+/** Reset the client (for testing) */
+export const _resetClient = (): void => {
+  replicateClient = null;
+};
+
+/** Set a custom client (for testing) */
+export const _setClient = (client: Replicate): void => {
+  replicateClient = client;
+};
+
+const getClient = (): Replicate => {
+  if (!replicateClient) {
+    const apiToken = process.env.REPLICATE_API_TOKEN;
+    if (!apiToken) {
+      throw new Error(
+        'REPLICATE_API_TOKEN environment variable is required. ' +
+        'Get your token at https://replicate.com/account/api-tokens'
+      );
+    }
+    replicateClient = new Replicate({ auth: apiToken });
+  }
+  return replicateClient;
+};
+
+/**
+ * Generate an image using the Replicate API
+ */
+export const generateImage = async (
+  options: GenerateImageOptions
+): Promise<GeneratedImage> => {
+  const {
+    prompt,
+    negativePrompt,
+    width,
+    height,
+    model = 'flux-schnell',
+  } = options;
+
+  const config = MODEL_CONFIGS[model];
+  const finalWidth = width ?? config.defaultWidth;
+  const finalHeight = height ?? config.defaultHeight;
+
+  const client = getClient();
+
+  const input: Record<string, unknown> = {
+    prompt,
+    width: finalWidth,
+    height: finalHeight,
+  };
+
+  if (negativePrompt) {
+    input.negative_prompt = negativePrompt;
+  }
+
+  // Model-specific input adjustments
+  if (model === 'flux-schnell') {
+    input.num_outputs = 1;
+    input.aspect_ratio = '4:3'; // Good for picture books
+    input.output_format = 'png';
+    input.output_quality = 90;
+  }
+
+  const output = await client.run(config.identifier, { input });
+
+  // Handle different output formats from different models
+  let imageUrl: string;
+
+  if (Array.isArray(output) && output.length > 0) {
+    const firstOutput = output[0];
+    if (typeof firstOutput === 'string') {
+      imageUrl = firstOutput;
+    } else if (firstOutput && typeof firstOutput === 'object' && 'url' in firstOutput) {
+      imageUrl = (firstOutput as { url: () => string }).url();
+    } else {
+      throw new Error('Unexpected output format from model');
+    }
+  } else if (typeof output === 'string') {
+    imageUrl = output;
+  } else {
+    throw new Error('Unexpected output format from model');
+  }
+
+  return {
+    url: imageUrl,
+    width: finalWidth,
+    height: finalHeight,
+  };
+};
+
+/**
+ * Download an image from URL and return as Buffer
+ */
+export const downloadImage = async (url: string): Promise<Buffer> => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to download image: ${response.statusText}`);
+  }
+  const arrayBuffer = await response.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+};

--- a/src/core/services/prompt-builder.test.ts
+++ b/src/core/services/prompt-builder.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest';
+import { buildBeatPrompt, buildSimplePrompt } from './prompt-builder';
+import type { StoryBeat, VisualStyleGuide, StoryCharacter } from '../schemas';
+
+describe('buildBeatPrompt', () => {
+  const minimalStyle: VisualStyleGuide = {
+    art_direction: {
+      genre: ['fantasy'],
+      medium: ['digital illustration'],
+      technique: ['soft shading'],
+    },
+    setting: {
+      landmarks: [],
+      diegetic_lights: [],
+    },
+  };
+
+  const minimalBeat: StoryBeat = {
+    order: 1,
+    purpose: 'setup',
+    summary: 'Luna discovers a magical garden gate',
+    emotion: 'curious',
+    characters: [],
+    shot: {
+      size: 'wide',
+      angle: 'eye_level',
+    },
+  };
+
+  const characters: Record<string, StoryCharacter> = {
+    luna: {
+      name: 'Luna',
+      description: 'A fluffy white rabbit with big curious eyes',
+      traits: ['curious', 'brave'],
+      notes: [],
+    },
+  };
+
+  it('includes beat summary in prompt', () => {
+    const { prompt } = buildBeatPrompt(minimalBeat, minimalStyle, {});
+    expect(prompt).toContain('Luna discovers a magical garden gate');
+  });
+
+  it('includes emotion in prompt', () => {
+    const { prompt } = buildBeatPrompt(minimalBeat, minimalStyle, {});
+    expect(prompt).toContain('curious mood');
+  });
+
+  it('includes art style from style guide', () => {
+    const { prompt } = buildBeatPrompt(minimalBeat, minimalStyle, {});
+    expect(prompt).toContain('fantasy');
+    expect(prompt).toContain('digital illustration');
+  });
+
+  it('includes shot composition', () => {
+    const { prompt } = buildBeatPrompt(minimalBeat, minimalStyle, {});
+    expect(prompt).toContain('wide shot');
+    expect(prompt).toContain('eye level');
+  });
+
+  it('includes character details when present', () => {
+    const beatWithCharacter: StoryBeat = {
+      ...minimalBeat,
+      characters: [
+        {
+          id: 'luna',
+          expression: 'surprised',
+          pose: 'standing upright',
+          focus: 'primary',
+        },
+      ],
+    };
+
+    const { prompt } = buildBeatPrompt(beatWithCharacter, minimalStyle, characters);
+    expect(prompt).toContain('Luna');
+    expect(prompt).toContain('fluffy white rabbit');
+    expect(prompt).toContain('surprised expression');
+    expect(prompt).toContain('standing upright pose');
+  });
+
+  it('includes setting details from beat override', () => {
+    const beatWithSetting: StoryBeat = {
+      ...minimalBeat,
+      setting: {
+        location: 'enchanted forest',
+        time_of_day: 'golden hour',
+        season: 'spring',
+        landmarks: [],
+        diegetic_lights: [],
+      },
+    };
+
+    const { prompt } = buildBeatPrompt(beatWithSetting, minimalStyle, {});
+    expect(prompt).toContain('enchanted forest');
+    expect(prompt).toContain('golden hour');
+    expect(prompt).toContain('spring');
+  });
+
+  it('falls back to global setting when beat has no setting', () => {
+    const styleWithSetting: VisualStyleGuide = {
+      ...minimalStyle,
+      setting: {
+        location: 'magical garden',
+        biome: 'temperate forest',
+        landmarks: [],
+        diegetic_lights: [],
+      },
+    };
+
+    const { prompt } = buildBeatPrompt(minimalBeat, styleWithSetting, {});
+    expect(prompt).toContain('magical garden');
+  });
+
+  it('includes lighting when present', () => {
+    const styleWithLighting: VisualStyleGuide = {
+      ...minimalStyle,
+      lighting: {
+        scheme: ['natural', 'soft'],
+        direction: ['side'],
+        quality: 'diffused',
+        temperature_K: 5500,
+      },
+    };
+
+    const { prompt } = buildBeatPrompt(minimalBeat, styleWithLighting, {});
+    expect(prompt).toContain('natural soft');
+    expect(prompt).toContain('side lighting');
+  });
+
+  it('includes warm lighting description for low temperature', () => {
+    const styleWithWarmLight: VisualStyleGuide = {
+      ...minimalStyle,
+      lighting: {
+        scheme: [],
+        direction: [],
+        temperature_K: 3000,
+      },
+    };
+
+    const { prompt } = buildBeatPrompt(minimalBeat, styleWithWarmLight, {});
+    expect(prompt).toContain('warm lighting');
+  });
+
+  it('includes color palette when present', () => {
+    const styleWithColor: VisualStyleGuide = {
+      ...minimalStyle,
+      color_script: {
+        palette: ['soft pink', 'lavender', 'mint green'],
+        accent_colors: [],
+        harmony: 'analogous',
+        saturation_level: 'medium',
+      },
+    };
+
+    const { prompt } = buildBeatPrompt(minimalBeat, styleWithColor, {});
+    expect(prompt).toContain('soft pink');
+    expect(prompt).toContain('analogous color harmony');
+  });
+
+  it('includes picture book qualifier', () => {
+    const { prompt } = buildBeatPrompt(minimalBeat, minimalStyle, {});
+    expect(prompt).toContain("children's picture book");
+  });
+
+  it('generates negative prompt with defaults', () => {
+    const { negativePrompt } = buildBeatPrompt(minimalBeat, minimalStyle, {});
+    expect(negativePrompt).toContain('blurry');
+    expect(negativePrompt).toContain('low quality');
+    expect(negativePrompt).toContain('scary');
+    expect(negativePrompt).toContain('violent');
+  });
+
+  it('includes custom constraints in negative prompt', () => {
+    const styleWithConstraints: VisualStyleGuide = {
+      ...minimalStyle,
+      constraints: {
+        negative: ['photorealistic', 'dark themes'],
+      },
+    };
+
+    const { negativePrompt } = buildBeatPrompt(minimalBeat, styleWithConstraints, {});
+    expect(negativePrompt).toContain('photorealistic');
+    expect(negativePrompt).toContain('dark themes');
+  });
+
+  it('handles composition rules', () => {
+    const beatWithComposition: StoryBeat = {
+      ...minimalBeat,
+      shot: {
+        size: 'medium',
+        angle: 'three_quarter_view',
+        composition: ['thirds_composition', 'negative_space'],
+      },
+    };
+
+    const { prompt } = buildBeatPrompt(beatWithComposition, minimalStyle, {});
+    expect(prompt).toContain('rule of thirds');
+    expect(prompt).toContain('negative space');
+  });
+});
+
+describe('buildSimplePrompt', () => {
+  it('generates watercolor style prompt', () => {
+    const { prompt } = buildSimplePrompt('a rabbit in a garden', 'watercolor');
+    expect(prompt).toContain('watercolor illustration');
+    expect(prompt).toContain('a rabbit in a garden');
+    expect(prompt).toContain("children's picture book");
+  });
+
+  it('generates digital style prompt', () => {
+    const { prompt } = buildSimplePrompt('a rabbit in a garden', 'digital');
+    expect(prompt).toContain('digital illustration');
+  });
+
+  it('generates cartoon style prompt', () => {
+    const { prompt } = buildSimplePrompt('a rabbit in a garden', 'cartoon');
+    expect(prompt).toContain('cartoon style');
+  });
+
+  it('generates realistic style prompt', () => {
+    const { prompt } = buildSimplePrompt('a rabbit in a garden', 'realistic');
+    expect(prompt).toContain('realistic illustration');
+  });
+
+  it('defaults to digital style', () => {
+    const { prompt } = buildSimplePrompt('a rabbit in a garden');
+    expect(prompt).toContain('digital illustration');
+  });
+
+  it('includes appropriate negative prompt', () => {
+    const { negativePrompt } = buildSimplePrompt('a rabbit in a garden');
+    expect(negativePrompt).toContain('blurry');
+    expect(negativePrompt).toContain('scary');
+    expect(negativePrompt).toContain('inappropriate');
+  });
+});

--- a/src/core/services/prompt-builder.ts
+++ b/src/core/services/prompt-builder.ts
@@ -1,0 +1,264 @@
+import type {
+  Story,
+  StoryBeat,
+  VisualStyleGuide,
+  StoryCharacter,
+  ShotComposition,
+} from '../schemas';
+
+/**
+ * Builds image generation prompts from Story data
+ *
+ * Combines beat description, character details, shot composition,
+ * and global style guide into a coherent prompt for image generation.
+ */
+
+export interface PromptParts {
+  prompt: string;
+  negativePrompt: string;
+}
+
+/**
+ * Build a complete prompt for a story beat
+ */
+export const buildBeatPrompt = (
+  beat: StoryBeat,
+  style: VisualStyleGuide,
+  characters: Record<string, StoryCharacter>,
+  pageText?: string
+): PromptParts => {
+  const parts: string[] = [];
+
+  // 1. Art style and medium
+  parts.push(buildStylePrefix(style));
+
+  // 2. Scene description from beat
+  parts.push(beat.summary);
+
+  // 3. Emotional tone
+  parts.push(`${beat.emotion} mood`);
+
+  // 4. Characters in scene
+  if (beat.characters.length > 0) {
+    const characterDescriptions = beat.characters
+      .map((beatChar) => {
+        const char = characters[beatChar.id];
+        if (!char) return null;
+        return `${char.name} (${char.description}), ${beatChar.expression} expression, ${beatChar.pose} pose`;
+      })
+      .filter(Boolean);
+
+    if (characterDescriptions.length > 0) {
+      parts.push(characterDescriptions.join('; '));
+    }
+  }
+
+  // 5. Shot composition
+  parts.push(buildShotDescription(beat.shot));
+
+  // 6. Setting details
+  if (beat.setting) {
+    const settingParts: string[] = [];
+    if (beat.setting.location) settingParts.push(beat.setting.location);
+    if (beat.setting.time_of_day) settingParts.push(beat.setting.time_of_day);
+    if (beat.setting.season) settingParts.push(beat.setting.season);
+    if (settingParts.length > 0) {
+      parts.push(settingParts.join(', '));
+    }
+  } else if (style.setting) {
+    // Fall back to global setting
+    const settingParts: string[] = [];
+    if (style.setting.location) settingParts.push(style.setting.location);
+    if (style.setting.biome) settingParts.push(style.setting.biome);
+    if (settingParts.length > 0) {
+      parts.push(settingParts.join(', '));
+    }
+  }
+
+  // 7. Lighting
+  if (beat.shot.overrides?.lighting || style.lighting) {
+    const lighting = beat.shot.overrides?.lighting ?? style.lighting;
+    if (lighting) {
+      parts.push(buildLightingDescription(lighting));
+    }
+  }
+
+  // 8. Color palette
+  if (beat.shot.overrides?.color || style.color_script) {
+    const color = beat.shot.overrides?.color ?? style.color_script;
+    if (color) {
+      parts.push(buildColorDescription(color));
+    }
+  }
+
+  // 9. Picture book style qualifier
+  parts.push('children\'s picture book illustration, high quality, detailed');
+
+  const prompt = parts.filter(Boolean).join(', ');
+
+  // Build negative prompt from constraints
+  const negativePrompt = buildNegativePrompt(style);
+
+  return { prompt, negativePrompt };
+};
+
+const buildStylePrefix = (style: VisualStyleGuide): string => {
+  const { art_direction } = style;
+  const parts: string[] = [];
+
+  if (art_direction.genre.length > 0) {
+    parts.push(art_direction.genre.join(' '));
+  }
+  if (art_direction.medium.length > 0) {
+    parts.push(art_direction.medium.join(', '));
+  }
+  if (art_direction.technique.length > 0) {
+    parts.push(art_direction.technique.join(', '));
+  }
+
+  return parts.join(', ') || 'digital illustration';
+};
+
+const buildShotDescription = (shot: ShotComposition): string => {
+  const parts: string[] = [];
+
+  // Shot size
+  const sizeMap: Record<string, string> = {
+    extreme_wide: 'extreme wide shot',
+    wide: 'wide shot',
+    medium_wide: 'medium wide shot',
+    medium: 'medium shot',
+    medium_close: 'medium close-up',
+    close_up: 'close-up',
+    extreme_close_up: 'extreme close-up',
+    macro_detail: 'macro detail shot',
+    insert_object: 'insert shot',
+  };
+  parts.push(sizeMap[shot.size] || shot.size);
+
+  // Camera angle
+  const angleMap: Record<string, string> = {
+    eye_level: 'eye level',
+    childs_eye: 'child\'s eye view',
+    high_angle: 'high angle',
+    birds_eye: 'bird\'s eye view',
+    worms_eye: 'worm\'s eye view',
+    low_angle_hero: 'low angle hero shot',
+    three_quarter_view: 'three-quarter view',
+    profile_side: 'profile view',
+    dutch_tilt: 'dutch angle',
+    isometric_view: 'isometric view',
+  };
+  parts.push(angleMap[shot.angle] || shot.angle);
+
+  // Composition rules
+  if (shot.composition && shot.composition.length > 0) {
+    const compMap: Record<string, string> = {
+      centered_hero: 'centered composition',
+      thirds_composition: 'rule of thirds',
+      symmetrical: 'symmetrical composition',
+      foreground_frame: 'foreground framing',
+      deep_space: 'deep space composition',
+      diagonal_composition: 'diagonal composition',
+      negative_space: 'negative space',
+      silhouette: 'silhouette',
+    };
+    const comps = shot.composition.map((c) => compMap[c] || c).filter(Boolean);
+    if (comps.length > 0) {
+      parts.push(comps.join(', '));
+    }
+  }
+
+  return parts.join(', ');
+};
+
+const buildLightingDescription = (lighting: Partial<{
+  scheme: string[];
+  direction: string[];
+  quality?: string;
+  temperature_K?: number;
+}>): string => {
+  const parts: string[] = [];
+
+  if (lighting.scheme && lighting.scheme.length > 0) {
+    parts.push(lighting.scheme.join(' '));
+  }
+  if (lighting.direction && lighting.direction.length > 0) {
+    parts.push(`${lighting.direction.join(' ')} lighting`);
+  }
+  if (lighting.quality) {
+    parts.push(`${lighting.quality} light`);
+  }
+  if (lighting.temperature_K) {
+    if (lighting.temperature_K < 4000) {
+      parts.push('warm lighting');
+    } else if (lighting.temperature_K > 6000) {
+      parts.push('cool lighting');
+    }
+  }
+
+  return parts.join(', ') || 'soft natural lighting';
+};
+
+const buildColorDescription = (color: Partial<{
+  harmony?: string;
+  palette: string[];
+  saturation_level?: string;
+  value_key?: string;
+}>): string => {
+  const parts: string[] = [];
+
+  if (color.palette && color.palette.length > 0) {
+    parts.push(color.palette.slice(0, 4).join(', ') + ' colors');
+  }
+  if (color.harmony) {
+    parts.push(`${color.harmony} color harmony`);
+  }
+  if (color.saturation_level) {
+    parts.push(`${color.saturation_level} saturation`);
+  }
+
+  return parts.join(', ');
+};
+
+const buildNegativePrompt = (style: VisualStyleGuide): string => {
+  const defaults = [
+    'blurry',
+    'low quality',
+    'distorted',
+    'deformed',
+    'ugly',
+    'bad anatomy',
+    'extra limbs',
+    'text',
+    'watermark',
+    'signature',
+    'scary',
+    'violent',
+    'inappropriate',
+  ];
+
+  const constraints = style.constraints?.negative ?? [];
+
+  return [...defaults, ...constraints].join(', ');
+};
+
+/**
+ * Build a simplified prompt for quick generation (without full style)
+ */
+export const buildSimplePrompt = (
+  description: string,
+  style: 'watercolor' | 'digital' | 'cartoon' | 'realistic' = 'digital'
+): PromptParts => {
+  const styleMap = {
+    watercolor: 'watercolor illustration, soft colors, hand-painted feel',
+    digital: 'digital illustration, vibrant colors, clean lines',
+    cartoon: 'cartoon style, bold outlines, bright colors',
+    realistic: 'realistic illustration, detailed, natural colors',
+  };
+
+  const prompt = `${styleMap[style]}, ${description}, children's picture book, high quality`;
+  const negativePrompt = 'blurry, low quality, scary, violent, inappropriate, text, watermark';
+
+  return { prompt, negativePrompt };
+};


### PR DESCRIPTION
## Summary
- Add image-generation service using Replicate API with support for flux-schnell, sdxl, and nano-banana-pro models
- Add prompt-builder to convert Story beats, VisualStyleGuide, and character data into image generation prompts
- Update illustrator agent to use real image generation (with mock mode for testing)
- Add CLI options: `--mock` (skip API calls), `--model` (select model), `--download` (save images locally)

## Changes
- New `src/core/services/image-generation.ts` - Replicate API client
- New `src/core/services/prompt-builder.ts` - Converts story data to image prompts
- Updated `src/core/agents/illustrator.ts` - Real image generation with configurable options
- Updated `src/cli/commands/render.ts` - New CLI flags for rendering options

## Test plan
- [x] Run `npm run test:run` - 136 tests passing
- [x] Run `npm run typecheck` - No errors
- [ ] Test `bookbug render <story.json> --mock` - Uses mock images
- [ ] Test `bookbug render <story.json>` - Requires REPLICATE_API_TOKEN env var
- [ ] Test `bookbug render <story.json> --download` - Downloads images to assets folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)