### PR TITLE
Extract model configuration to centralized config

### DIFF
--- a/src/core/agents/author.ts
+++ b/src/core/agents/author.ts
@@ -1,6 +1,6 @@
 import { generateObject } from 'ai';
-import { anthropic } from '@ai-sdk/anthropic';
 import { ManuscriptSchema, type StoryBlurb, type Manuscript } from '../schemas';
+import { getModel } from '../config';
 import type { AuthorAgent } from './index';
 
 const SYSTEM_PROMPT = `You are a children's book author. Given a StoryBlurb (with brief and plot beats), write a complete manuscript with text for each page.
@@ -31,7 +31,7 @@ Keep the tone consistent. Honor the plot beats. Make it magical.`;
  */
 export const authorAgent: AuthorAgent = async (blurb: StoryBlurb): Promise<Manuscript> => {
   const { object } = await generateObject({
-    model: anthropic('claude-sonnet-4-5-20250929'),
+    model: getModel(),
     schema: ManuscriptSchema,
     system: SYSTEM_PROMPT,
     prompt: JSON.stringify(blurb, null, 2),

--- a/src/core/agents/blurb-conversation.ts
+++ b/src/core/agents/blurb-conversation.ts
@@ -1,10 +1,10 @@
 import { generateObject } from 'ai';
-import { anthropic } from '@ai-sdk/anthropic';
 import {
   BlurbConversationResponseSchema,
   type BlurbConversationResponse,
   type StoryBlurb,
 } from '../schemas';
+import { getModel } from '../config';
 
 const SYSTEM_PROMPT = `You help users refine their story's plot beats through conversation.
 
@@ -50,7 +50,7 @@ export const blurbConversationAgent = async (
   const blurbContext = `Current StoryBlurb:\n${JSON.stringify(currentBlurb, null, 2)}`;
 
   const { object } = await generateObject({
-    model: anthropic('claude-sonnet-4-5-20250929'),
+    model: getModel(),
     schema: BlurbConversationResponseSchema,
     system: SYSTEM_PROMPT,
     messages: [

--- a/src/core/agents/blurb-generator.ts
+++ b/src/core/agents/blurb-generator.ts
@@ -1,6 +1,6 @@
 import { generateObject } from 'ai';
-import { anthropic } from '@ai-sdk/anthropic';
 import { StoryBlurbSchema, type StoryBrief, type StoryBlurb } from '../schemas';
+import { getModel } from '../config';
 
 const SYSTEM_PROMPT = `You are a children's book story planner. Given a StoryBrief, expand it into a StoryBlurb with detailed plot beats.
 
@@ -27,7 +27,7 @@ Keep language simple - these will guide page-by-page writing.`;
  */
 export const blurbGeneratorAgent = async (brief: StoryBrief): Promise<StoryBlurb> => {
   const { object } = await generateObject({
-    model: anthropic('claude-sonnet-4-5-20250929'),
+    model: getModel(),
     schema: StoryBlurbSchema,
     system: SYSTEM_PROMPT,
     prompt: JSON.stringify(brief, null, 2),

--- a/src/core/agents/blurb-interpreter.ts
+++ b/src/core/agents/blurb-interpreter.ts
@@ -1,6 +1,6 @@
 import { generateObject } from 'ai';
-import { anthropic } from '@ai-sdk/anthropic';
 import { StoryBlurbSchema, type StoryBlurb } from '../schemas';
+import { getModel } from '../config';
 
 const SYSTEM_PROMPT = `You modify a StoryBlurb's plot beats based on user feedback.
 
@@ -36,7 +36,7 @@ export const blurbInterpreterAgent = async (
   const contextualPrompt = `Current StoryBlurb:\n${JSON.stringify(currentBlurb, null, 2)}\n\nUser feedback:\n${userFeedback}`;
 
   const { object } = await generateObject({
-    model: anthropic('claude-sonnet-4-5-20250929'),
+    model: getModel(),
     schema: StoryBlurbSchema,
     system: SYSTEM_PROMPT,
     prompt: contextualPrompt,

--- a/src/core/agents/conversation.ts
+++ b/src/core/agents/conversation.ts
@@ -1,10 +1,10 @@
 import { generateObject } from 'ai';
-import { anthropic } from '@ai-sdk/anthropic';
 import {
   ConversationResponseSchema,
   type ConversationResponse,
   type StoryBrief,
 } from '../schemas';
+import { getModel } from '../config';
 
 const SYSTEM_PROMPT = `You guide users through creating a StoryBrief by asking focused questions about what's missing.
 
@@ -61,7 +61,7 @@ export const conversationAgent = async (
   const briefContext = `Current StoryBrief state:\n${JSON.stringify(currentBrief, null, 2)}`;
 
   const { object } = await generateObject({
-    model: anthropic('claude-sonnet-4-5-20250929'),
+    model: getModel(),
     schema: ConversationResponseSchema,
     system: SYSTEM_PROMPT,
     messages: [

--- a/src/core/agents/director.ts
+++ b/src/core/agents/director.ts
@@ -1,6 +1,6 @@
 import { generateObject } from 'ai';
-import { anthropic } from '@ai-sdk/anthropic';
 import { StorySchema, type Manuscript, type Story } from '../schemas';
+import { getModel } from '../config';
 import type { DirectorAgent } from './index';
 
 const SYSTEM_PROMPT = `You are an art director for children's picture books. Given a Manuscript, create a complete visual Story with detailed shot compositions for each beat.
@@ -28,7 +28,7 @@ Output a complete Story ready for illustration.`;
  */
 export const directorAgent: DirectorAgent = async (manuscript: Manuscript): Promise<Story> => {
   const { object } = await generateObject({
-    model: anthropic('claude-sonnet-4-5-20250929'),
+    model: getModel(),
     schema: StorySchema,
     system: SYSTEM_PROMPT,
     prompt: JSON.stringify(manuscript, null, 2),

--- a/src/core/agents/interpreter.ts
+++ b/src/core/agents/interpreter.ts
@@ -1,6 +1,6 @@
 import { generateObject } from 'ai';
-import { anthropic } from '@ai-sdk/anthropic';
 import { StoryBriefSchema, type StoryBrief } from '../schemas';
+import { getModel } from '../config';
 
 const SYSTEM_PROMPT = `You extract story details from user input into a StoryBrief. Be thorough but don't invent details the user didn't provide.
 
@@ -47,7 +47,7 @@ export const interpreterAgent = async (
     : userMessage;
 
   const { object } = await generateObject({
-    model: anthropic('claude-sonnet-4-5-20250929'),
+    model: getModel(),
     schema: StoryBriefSchema.partial(),
     system: SYSTEM_PROMPT,
     prompt: contextualPrompt,

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,0 +1,30 @@
+import { anthropic } from '@ai-sdk/anthropic';
+
+/**
+ * AI Model Configuration
+ *
+ * Centralized model configuration for all agents.
+ * Change the model ID here to switch all agents at once.
+ */
+
+const DEFAULT_MODEL_ID = 'claude-sonnet-4-5-20250929';
+
+/**
+ * Get the configured model ID, with environment override support
+ */
+export const getModelId = (): string => {
+  return process.env.BOOKBUG_MODEL_ID ?? DEFAULT_MODEL_ID;
+};
+
+/**
+ * Get the configured Anthropic model instance
+ *
+ * Usage:
+ * ```ts
+ * import { getModel } from '../config';
+ * const result = await generateObject({ model: getModel(), ... });
+ * ```
+ */
+export const getModel = () => {
+  return anthropic(getModelId());
+};


### PR DESCRIPTION
## Summary
- Centralizes hardcoded model ID from 7 agent files into `src/core/config.ts`
- Adds environment variable override support (`BOOKBUG_MODEL_ID`)

## Principle Applied
**Write code that is easy to delete** - Model configuration is now in one place. Swapping providers or models requires changing one file, not seven.

## Changes
| File | Change |
|------|--------|
| `src/core/config.ts` | NEW - `getModel()` and `getModelId()` |
| `src/core/agents/author.ts` | Use `getModel()` |
| `src/core/agents/director.ts` | Use `getModel()` |
| `src/core/agents/interpreter.ts` | Use `getModel()` |
| `src/core/agents/conversation.ts` | Use `getModel()` |
| `src/core/agents/blurb-generator.ts` | Use `getModel()` |
| `src/core/agents/blurb-conversation.ts` | Use `getModel()` |
| `src/core/agents/blurb-interpreter.ts` | Use `getModel()` |

## Usage
```bash
# Use default model
npm run dev

# Override with different model
BOOKBUG_MODEL_ID=claude-3-opus-20240229 npm run dev
```

## Test plan
- [x] All 153 tests pass
- [x] TypeScript typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)