### PR TITLE
Replace null as any with discriminated union in PipelineResult

### DIFF
--- a/src/cli/commands/create.ts
+++ b/src/cli/commands/create.ts
@@ -39,7 +39,10 @@ export const createCommand = new Command('create')
         },
       });
 
-      // Save all artifacts
+      // Save all artifacts (pipeline always completes to 'book' stage here)
+      if (result.stage !== 'book') {
+        throw new Error('Pipeline did not complete');
+      }
       await outputManager.saveManuscript(result.manuscript);
       await outputManager.saveStory(result.story);
       await outputManager.saveBook(result.book);


### PR DESCRIPTION
## Summary
Fixes type safety issue where partial pipeline results used `null as any` to satisfy the type checker.

## Principle Applied
**Prefer explicit over implicit** - The pipeline result type now explicitly declares what's available at each stage, instead of hiding incomplete state behind `any`.

## Changes

**Before:**
```typescript
export interface PipelineResult {
  blurb: StoryBlurb;
  manuscript: Manuscript;
  story: Story;  // could be null as any
  book: Book;    // could be null as any
}
```

**After:**
```typescript
export type PipelineResult =
  | { stage: 'manuscript'; blurb: StoryBlurb; manuscript: Manuscript }
  | { stage: 'story'; blurb: StoryBlurb; manuscript: Manuscript; story: Story }
  | { stage: 'book'; blurb: StoryBlurb; manuscript: Manuscript; story: Story; book: Book };
```

## Usage
```typescript
const result = await executePipeline(blurb, { stopAfter: 'story' });

if (result.stage === 'book') {
  // TypeScript knows result.book exists here
  console.log(result.book);
}
```

## Test plan
- [x] All 153 tests pass
- [x] TypeScript typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)