### PR TITLE
Rename types for clarity

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -88,8 +88,8 @@ All types are defined in `src/core/schemas/index.ts`. Key schemas:
 | Schema | Description |
 |--------|-------------|
 | `Story` | Complete visual story (normalized blob) |
-| `StoryPage` | Page with visual beats |
-| `StoryBeat` | Single illustration: shot composition, characters, emotion |
+| `IllustratedPage` | Page with visual beats |
+| `IllustrationBeat` | Single illustration: shot composition, characters, emotion |
 | `VisualStyleGuide` | Global art direction, lighting, colors |
 | `ShotComposition` | Camera: size, angle, POV, staging, cinematography |
 
@@ -105,8 +105,8 @@ All types are defined in `src/core/schemas/index.ts`. Key schemas:
 ### Output Types
 | Schema | Description |
 |--------|-------------|
-| `Book` | Final rendered book with pages and images |
-| `BookPage` | Page with text and rendered images |
+| `RenderedBook` | Final rendered book with pages and images |
+| `RenderedPage` | Page with rendered image URL |
 | `RenderedImage` | Generated image: url, dimensions, metadata |
 
 ---
@@ -244,7 +244,7 @@ Story {
     pages: Record<pageNum, ManuscriptPage>  // Lookup table
   }
   style: VisualStyleGuide
-  pages: StoryPage[]                        // References lookups by ID
+  pages: IllustratedPage[]                  // References lookups by ID
 }
 ```
 

--- a/src/cli/commands/create.ts
+++ b/src/cli/commands/create.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { executePipeline } from '../../core/pipeline';
-import type { Manuscript, Story, Book } from '../../core/schemas';
+import type { Manuscript, Story, RenderedBook } from '../../core/schemas';
 import { runStoryIntake } from '../prompts/story-intake';
 import { runBlurbIntake } from '../prompts/blurb-intake';
 import { createSpinner, formatStep } from '../output/progress';

--- a/src/cli/commands/render.ts
+++ b/src/cli/commands/render.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { renderPage, renderPageMock, createBook } from '../../core/pipeline';
-import { StorySchema, type BookFormatKey, type Book, type RenderedPage } from '../../core/schemas';
+import { StorySchema, type BookFormatKey, type RenderedBook, type RenderedPage } from '../../core/schemas';
 import { createSpinner } from '../output/progress';
 import { displayBook } from '../output/display';
 import { loadOutputManager, isStoryFolder, createOutputManager } from '../utils/output';
@@ -60,7 +60,7 @@ export const renderCommand = new Command('render')
       const book = createBook(story, pages, format);
 
       // Download images and save locally (skip in mock mode)
-      let finalBook: Book;
+      let finalBook: RenderedBook;
       if (options.mock) {
         finalBook = book;
       } else {
@@ -88,13 +88,13 @@ export const renderCommand = new Command('render')
 
 /**
  * Download images from temporary URLs and save to local disk.
- * Returns a new Book with updated local paths.
+ * Returns a new RenderedBook with updated local paths.
  */
 async function downloadAndSaveImages(
-  book: Book,
+  book: RenderedBook,
   assetsFolder: string,
   onProgress?: (completed: number, total: number) => void
-): Promise<Book> {
+): Promise<RenderedBook> {
   const updatedPages = [];
   const total = book.pages.length;
 

--- a/src/cli/output/display.test.ts
+++ b/src/cli/output/display.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { displayBrief, displayManuscript, displayStory, displayBook } from './display';
-import type { StoryBrief, Manuscript, Story, Book } from '../../core/schemas';
+import type { StoryBrief, Manuscript, Story, RenderedBook } from '../../core/schemas';
 
 // Mock console.log to capture output
 const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -257,7 +257,7 @@ describe('displayStory', () => {
 });
 
 describe('displayBook', () => {
-  const minimalBook: Book = {
+  const minimalBook: RenderedBook = {
     storyTitle: 'The Magic Garden',
     ageRange: { min: 4, max: 8 },
     format: 'square-large',

--- a/src/cli/output/display.ts
+++ b/src/cli/output/display.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import type { StoryBrief, Manuscript, Story, Book } from '../../core/schemas';
+import type { StoryBrief, Manuscript, Story, RenderedBook } from '../../core/schemas';
 
 /**
  * Display a StoryBrief summary
@@ -71,9 +71,9 @@ export function displayStory(story: Story): void {
 }
 
 /**
- * Display a Book summary
+ * Display a RenderedBook summary
  */
-export function displayBook(book: Book): void {
+export function displayBook(book: RenderedBook): void {
   console.log('\n' + chalk.bold.yellow('📚 Generated Book'));
   console.log(chalk.gray('─'.repeat(50)));
   console.log(chalk.bold('Title:'), book.storyTitle);

--- a/src/cli/utils/output.ts
+++ b/src/cli/utils/output.ts
@@ -5,7 +5,7 @@ import type {
   StoryBlurb,
   Manuscript,
   Story,
-  Book,
+  RenderedBook,
 } from '../../core/schemas';
 import { generateStoryFolder } from './naming';
 
@@ -25,8 +25,8 @@ export interface StoryOutputManager {
   saveManuscript(manuscript: Manuscript): Promise<void>;
   /** Save Story to story.json */
   saveStory(story: Story): Promise<void>;
-  /** Save Book to book.json */
-  saveBook(book: Book): Promise<void>;
+  /** Save RenderedBook to book.json */
+  saveBook(book: RenderedBook): Promise<void>;
 }
 
 /**

--- a/src/core/agents/index.ts
+++ b/src/core/agents/index.ts
@@ -1,4 +1,4 @@
-import type { StoryBrief, StoryBlurb, Manuscript, Story, Book } from '../schemas';
+import type { StoryBrief, StoryBlurb, Manuscript, Story, RenderedBook } from '../schemas';
 
 /**
  * Generic agent type: async function from Input to Output

--- a/src/core/agents/renderer.ts
+++ b/src/core/agents/renderer.ts
@@ -1,4 +1,4 @@
-import type { Story, Book, RenderedPage, BookFormatKey, StorySlice } from '../schemas';
+import type { Story, RenderedBook, RenderedPage, BookFormatKey, StorySlice } from '../schemas';
 import { BOOK_FORMATS } from '../schemas';
 import { generatePageImage } from '../services/image-generation';
 
@@ -32,7 +32,7 @@ export const renderPageMock = (pageNumber: number): RenderedPage => ({
 });
 
 /**
- * Assemble rendered pages into a Book
+ * Assemble rendered pages into a RenderedBook
  *
  * This is a pure function - no generation, just structure.
  * Pages should already be rendered via renderPage/renderPageMock.
@@ -41,7 +41,7 @@ export const createBook = (
   story: Story,
   pages: RenderedPage[],
   format: BookFormatKey = 'square-large'
-): Book => ({
+): RenderedBook => ({
   storyTitle: story.storyTitle,
   ageRange: story.ageRange,
   format,

--- a/src/core/pipeline.ts
+++ b/src/core/pipeline.ts
@@ -1,4 +1,4 @@
-import type { StoryBlurb, Manuscript, Story, Book, BookFormatKey, RenderedPage } from './schemas';
+import type { StoryBlurb, Manuscript, Story, RenderedBook, BookFormatKey, RenderedPage } from './schemas';
 import {
   authorAgent,
   illustratorAgent,
@@ -19,7 +19,7 @@ import {
 export type PipelineResult =
   | { stage: 'manuscript'; blurb: StoryBlurb; manuscript: Manuscript }
   | { stage: 'story'; blurb: StoryBlurb; manuscript: Manuscript; story: Story }
-  | { stage: 'book'; blurb: StoryBlurb; manuscript: Manuscript; story: Story; book: Book };
+  | { stage: 'book'; blurb: StoryBlurb; manuscript: Manuscript; story: Story; book: RenderedBook };
 
 /**
  * Pipeline options
@@ -37,7 +37,7 @@ export interface PipelineOptions {
  * Pipeline flow:
  *   StoryBlurb → Author → Manuscript
  *   Manuscript → Illustrator → Story
- *   Story → Renderer → Book
+ *   Story → Renderer → RenderedBook
  *
  * Note: StoryBlurb is created via:
  *   1. runStoryIntake (chat) → StoryBrief
@@ -102,7 +102,7 @@ export { renderPage, renderPageMock, createBook } from './agents';
 export async function runBook(
   story: Story,
   config?: { mock?: boolean; format?: BookFormatKey; onPageRendered?: (page: RenderedPage) => void }
-): Promise<Book> {
+): Promise<RenderedBook> {
   const { mock = false, format = 'square-large', onPageRendered } = config ?? {};
 
   const pages: RenderedPage[] = [];

--- a/src/core/schemas/index.ts
+++ b/src/core/schemas/index.ts
@@ -282,8 +282,8 @@ export const BeatCharacterSchema = z.object({
 
 export type BeatCharacter = z.infer<typeof BeatCharacterSchema>;
 
-// StoryBeat: one narrative moment + visual shot description
-export const StoryBeatSchema = z.object({
+// IllustrationBeat: one visual moment with shot composition
+export const IllustrationBeatSchema = z.object({
   order: z.number().int().min(1),
   purpose: z.enum(["setup", "build", "twist", "climax", "payoff", "button"]),
   summary: z.string().min(1),
@@ -293,7 +293,7 @@ export const StoryBeatSchema = z.object({
   shot: ShotCompositionSchema,
 });
 
-export type StoryBeat = z.infer<typeof StoryBeatSchema>;
+export type IllustrationBeat = z.infer<typeof IllustrationBeatSchema>;
 
 // VisualStyleGuide: Global visual style applied across the entire book
 export const VisualStyleGuideSchema = z.object({
@@ -314,13 +314,13 @@ export const VisualStyleGuideSchema = z.object({
 
 export type VisualStyleGuide = z.infer<typeof VisualStyleGuideSchema>;
 
-// StoryPage: a single page with visual beats
-export const StoryPageSchema = z.object({
+// IllustratedPage: a single page with visual beats
+export const IllustratedPageSchema = z.object({
   pageNumber: z.number().int().min(1),
-  beats: z.array(StoryBeatSchema).min(1),
+  beats: z.array(IllustrationBeatSchema).min(1),
 });
 
-export type StoryPage = z.infer<typeof StoryPageSchema>;
+export type IllustratedPage = z.infer<typeof IllustratedPageSchema>;
 
 /**
  * Story: complete story ready for rendering
@@ -344,13 +344,13 @@ export const StorySchema = z.object({
     pages: z.record(z.string(), ManuscriptPageSchema),
   }),
   style: VisualStyleGuideSchema,
-  pages: z.array(StoryPageSchema).min(1),
+  pages: z.array(IllustratedPageSchema).min(1),
 });
 
 export type Story = z.infer<typeof StorySchema>;
 
 // ============================================================
-// 5. ILLUSTRATOR → Book (final rendered book)
+// 5. RENDERER → RenderedBook (final rendered book)
 // ============================================================
 
 // Import and re-export format types and utilities
@@ -378,7 +378,7 @@ export const RenderedPageSchema = z.object({
 
 export type RenderedPage = z.infer<typeof RenderedPageSchema>;
 
-export const BookSchema = z.object({
+export const RenderedBookSchema = z.object({
   storyTitle: z.string().min(1),
   ageRange: AgeRangeSchema,
   format: _BookFormatKeySchema.default('square-large'),
@@ -386,7 +386,7 @@ export const BookSchema = z.object({
   createdAt: z.string().datetime(),
 });
 
-export type Book = z.infer<typeof BookSchema>;
+export type RenderedBook = z.infer<typeof RenderedBookSchema>;
 
 // ============================================================
 // 6. IMAGE GENERATION (intermediate types)
@@ -403,7 +403,7 @@ export const StorySliceSchema = z.object({
   page: z.object({
     pageNumber: z.number().int().min(1),
     text: z.string().optional(),
-    beats: z.array(StoryBeatSchema).optional(),
+    beats: z.array(IllustrationBeatSchema).optional(),
   }),
 });
 


### PR DESCRIPTION
## Summary
- `StoryBeat` → `IllustrationBeat` (visual direction, not story content)
- `StoryPage` → `IllustratedPage` (contains visual beats)
- `Book` → `RenderedBook` (it's the rendered output)

## Rationale
The old names were confusing:
- "StoryBeat" sounded like story content, but it's visual direction
- "Book" was ambiguous - now "RenderedBook" clearly indicates it's the final rendered output

## Test plan
- [x] All 153 tests pass
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)