### PR TITLE
Add automatic stage output saving to pipeline

### DIFF
--- a/src/cli/utils/output.test.ts
+++ b/src/cli/utils/output.test.ts
@@ -64,6 +64,18 @@ describe('createOutputManager', () => {
     );
   });
 
+  it('saveProse writes to prose.json', async () => {
+    const manager = await createOutputManager('Test Story');
+    const storyWithProse = { prose: { logline: 'Test' } } as any;
+
+    await manager.saveProse(storyWithProse);
+
+    expect(mockedFs.writeFile).toHaveBeenCalledWith(
+      'output/test-story-20241126-143052/prose.json',
+      JSON.stringify(storyWithProse, null, 2)
+    );
+  });
+
   it('saveStory writes to story.json', async () => {
     const manager = await createOutputManager('Test Story');
     const story = { storyTitle: 'Test' } as any;
@@ -129,10 +141,10 @@ describe('loadOutputManager', () => {
     expect(manager.folder).toBe('/path');
   });
 
-  it('accepts folder with manuscript.json', async () => {
-    mockedFs.readdir.mockResolvedValue(['manuscript.json'] as any);
+  it('accepts folder with prose.json', async () => {
+    mockedFs.readdir.mockResolvedValue(['prose.json'] as any);
 
-    const manager = await loadOutputManager('/path/manuscript.json');
+    const manager = await loadOutputManager('/path/prose.json');
     expect(manager.folder).toBe('/path');
   });
 
@@ -164,7 +176,7 @@ describe('isStoryFolder', () => {
   });
 
   it('returns true if folder contains any artifact file', async () => {
-    mockedFs.readdir.mockResolvedValue(['manuscript.json'] as any);
+    mockedFs.readdir.mockResolvedValue(['prose.json'] as any);
 
     const result = await isStoryFolder('/path/to/story/file.txt');
     expect(result).toBe(true);

--- a/src/cli/utils/output.ts
+++ b/src/cli/utils/output.ts
@@ -3,13 +3,14 @@ import * as path from 'path';
 import type {
   StoryBrief,
   StoryWithPlot,
+  StoryWithProse,
   Story,
   RenderedBook,
 } from '../../core/schemas';
 import { createStoryFolderName } from './naming';
 
 const OUTPUT_DIR = './output';
-const ARTIFACT_FILES = ['brief.json', 'blurb.json', 'manuscript.json', 'story.json', 'book.json'];
+const ARTIFACT_FILES = ['brief.json', 'blurb.json', 'prose.json', 'story.json', 'book.json'];
 
 const saveJson = (folder: string, filename: string, data: unknown): Promise<void> =>
   fs.writeFile(path.join(folder, filename), JSON.stringify(data, null, 2));
@@ -24,6 +25,8 @@ export interface StoryOutputManager {
   saveBrief(brief: StoryBrief): Promise<void>;
   /** Save StoryWithPlot to blurb.json (composed brief + plot) */
   saveBlurb(story: StoryWithPlot): Promise<void>;
+  /** Save StoryWithProse to prose.json (composed brief + plot + prose) */
+  saveProse(story: StoryWithProse): Promise<void>;
   /** Save Story to story.json */
   saveStory(story: Story): Promise<void>;
   /** Save RenderedBook to book.json */
@@ -79,6 +82,7 @@ const createManager = (folder: string): StoryOutputManager => ({
   folder,
   saveBrief: (brief) => saveJson(folder, 'brief.json', brief),
   saveBlurb: (blurb) => saveJson(folder, 'blurb.json', blurb),
+  saveProse: (story) => saveJson(folder, 'prose.json', story),
   saveStory: (story) => saveJson(folder, 'story.json', story),
   saveBook: (book) => saveJson(folder, 'book.json', book),
 });


### PR DESCRIPTION
## Summary
- Add `saveProse(StoryWithProse)` method to StoryOutputManager
- Add `outputManager` option to `executePipeline` - saves artifacts at each stage
- Add `--no-save` CLI flag to create command (defaults to saving enabled)
- Replace `manuscript.json` with `prose.json` in artifact file list

## Folder Structure
```
output/{title}-{timestamp}/
├── brief.json    # Stage 1: StoryBrief
├── blurb.json    # Stage 2: StoryWithPlot  
├── prose.json    # Stage 3: StoryWithProse (NEW)
├── story.json    # Stage 4: ComposedStory
├── book.json     # Stage 5: RenderedBook
└── assets/
```

## Test plan
- [x] All 147 tests pass
- [x] TypeScript compiles without errors
- [ ] Manual test: run `npm run dev create` and verify all artifacts saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)