### PR TITLE
refactor: Extract pipeline progress callbacks into createPipelineProgress

### DIFF
--- a/src/cli/commands/create.ts
+++ b/src/cli/commands/create.ts
@@ -4,10 +4,9 @@ import { executePipeline } from '../../core/pipeline';
 import { progressMessagesAgent } from '../../core/agents';
 import { runStoryIntake } from '../prompts/story-intake';
 import { runPlotIntake } from '../prompts/plot-intake';
-import { createSpinner, formatStep } from '../output/progress';
+import { createSpinner, createPipelineProgress } from '../output/progress';
 import { displayBook } from '../output/display';
 import { createOutputManager, type StoryOutputManager } from '../utils/output';
-import { createProgressRotator, type ProgressRotator } from '../utils/progress-rotator';
 import { createLogger } from '../../core/utils/logger';
 
 export const createCommand = new Command('create')
@@ -45,38 +44,15 @@ export const createCommand = new Command('create')
       spinner.succeed('Progress messages ready');
 
       // Step 4: Run pipeline from StoryWithPlot to book
-      // Progress rotator shows witty messages during long-running phases
-      let rotator: ProgressRotator | null = null;
-      const majorPhases = ['prose', 'visuals', 'render'];
-      const longRunningPhases = ['prose', 'visuals'];
+      const { onProgress, onThinking } = createPipelineProgress({
+        spinner,
+        progressMessages,
+      });
 
       const { book } = await executePipeline(storyWithPlot, {
         logger,
-        onProgress: (step, status) => {
-          if (status === 'start') {
-            spinner.start(formatStep(step));
-            // Start rotator for long-running phases
-            if (longRunningPhases.includes(step)) {
-              rotator = createProgressRotator(progressMessages, 3000, (msg) => {
-                if (spinner.isSpinning) spinner.text = msg;
-              });
-              rotator.start();
-            }
-          } else if (status === 'complete') {
-            // Stop rotator when phase completes
-            if (longRunningPhases.includes(step)) {
-              rotator?.stop();
-              rotator = null;
-            }
-            if (majorPhases.includes(step)) {
-              spinner.succeed(formatStep(step, true));
-            }
-          }
-        },
-        onThinking: (msg) => {
-          // Still show pipeline-level thinking for non-rotating phases
-          if (spinner.isSpinning && !rotator) spinner.text = msg;
-        },
+        onProgress,
+        onThinking,
         outputManager: options.save !== false ? outputManager : undefined,
       });
 

--- a/src/cli/commands/resume.ts
+++ b/src/cli/commands/resume.ts
@@ -11,10 +11,9 @@ import {
   RenderedBookSchema,
   type BookFormatKey,
 } from '../../core/schemas';
-import { createSpinner, formatStep } from '../output/progress';
+import { createSpinner, createPipelineProgress } from '../output/progress';
 import { displayBook } from '../output/display';
 import { loadOutputManager } from '../utils/output';
-import { createProgressRotator, type ProgressRotator } from '../utils/progress-rotator';
 import { loadJson } from '../../utils';
 import { runPlotIntake } from '../prompts/plot-intake';
 
@@ -172,33 +171,14 @@ export const resumeCommand = new Command('resume')
           const progressMessages = await progressMessagesAgent(storyWithPlot);
           spinner.succeed('Ready');
 
-          let rotator: ProgressRotator | null = null;
-          const majorPhases = ['prose', 'visuals', 'render'];
-          const longRunningPhases = ['prose', 'visuals'];
+          const { onProgress, onThinking } = createPipelineProgress({
+            spinner,
+            progressMessages,
+          });
 
           const result = await executePipeline(storyWithPlot, {
-            onProgress: (step, status) => {
-              if (status === 'start') {
-                spinner.start(formatStep(step));
-                if (longRunningPhases.includes(step)) {
-                  rotator = createProgressRotator(progressMessages, 3000, (msg) => {
-                    if (spinner.isSpinning) spinner.text = msg;
-                  });
-                  rotator.start();
-                }
-              } else if (status === 'complete') {
-                if (longRunningPhases.includes(step)) {
-                  rotator?.stop();
-                  rotator = null;
-                }
-                if (majorPhases.includes(step)) {
-                  spinner.succeed(formatStep(step, true));
-                }
-              }
-            },
-            onThinking: (msg) => {
-              if (spinner.isSpinning && !rotator) spinner.text = msg;
-            },
+            onProgress,
+            onThinking,
             outputManager,
             format: options.format,
           });
@@ -220,33 +200,14 @@ export const resumeCommand = new Command('resume')
           const progressMessages = await progressMessagesAgent(storyWithPlot);
           spinner.succeed('Ready');
 
-          let rotator: ProgressRotator | null = null;
-          const majorPhases = ['prose', 'visuals', 'render'];
-          const longRunningPhases = ['prose', 'visuals'];
+          const { onProgress, onThinking } = createPipelineProgress({
+            spinner,
+            progressMessages,
+          });
 
           const result = await executePipeline(storyWithPlot, {
-            onProgress: (step, status) => {
-              if (status === 'start') {
-                spinner.start(formatStep(step));
-                if (longRunningPhases.includes(step)) {
-                  rotator = createProgressRotator(progressMessages, 3000, (msg) => {
-                    if (spinner.isSpinning) spinner.text = msg;
-                  });
-                  rotator.start();
-                }
-              } else if (status === 'complete') {
-                if (longRunningPhases.includes(step)) {
-                  rotator?.stop();
-                  rotator = null;
-                }
-                if (majorPhases.includes(step)) {
-                  spinner.succeed(formatStep(step, true));
-                }
-              }
-            },
-            onThinking: (msg) => {
-              if (spinner.isSpinning && !rotator) spinner.text = msg;
-            },
+            onProgress,
+            onThinking,
             outputManager,
             format: options.format,
           });

--- a/src/cli/output/progress.test.ts
+++ b/src/cli/output/progress.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { createSpinner, formatStep, progressBar } from './progress';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createSpinner, formatStep, progressBar, createPipelineProgress } from './progress';
 
 describe('createSpinner', () => {
   it('returns a spinner instance with dots spinner', () => {
@@ -72,5 +72,141 @@ describe('progressBar', () => {
     // Width 30 = 15 filled, 15 empty
     const barContent = result.slice(1, result.indexOf(']'));
     expect(barContent.length).toBe(30);
+  });
+});
+
+describe('createPipelineProgress', () => {
+  const createMockSpinner = () => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+    succeed: vi.fn(),
+    fail: vi.fn(),
+    text: '',
+    isSpinning: true,
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns onProgress and onThinking callbacks', () => {
+    const spinner = createMockSpinner();
+    const { onProgress, onThinking } = createPipelineProgress({
+      spinner: spinner as unknown as ReturnType<typeof createSpinner>,
+      progressMessages: ['msg1', 'msg2'],
+    });
+
+    expect(typeof onProgress).toBe('function');
+    expect(typeof onThinking).toBe('function');
+  });
+
+  it('starts spinner on phase start', () => {
+    const spinner = createMockSpinner();
+    const { onProgress } = createPipelineProgress({
+      spinner: spinner as unknown as ReturnType<typeof createSpinner>,
+      progressMessages: ['msg1'],
+    });
+
+    onProgress('prose', 'start');
+    expect(spinner.start).toHaveBeenCalledWith('Writing prose...');
+  });
+
+  it('calls succeed on major phase complete', () => {
+    const spinner = createMockSpinner();
+    const { onProgress } = createPipelineProgress({
+      spinner: spinner as unknown as ReturnType<typeof createSpinner>,
+      progressMessages: ['msg1'],
+    });
+
+    onProgress('prose', 'complete');
+    expect(spinner.succeed).toHaveBeenCalledWith('Writing prose ✓');
+  });
+
+  it('starts rotator for long-running phases', () => {
+    const spinner = createMockSpinner();
+    const { onProgress } = createPipelineProgress({
+      spinner: spinner as unknown as ReturnType<typeof createSpinner>,
+      progressMessages: ['msg1', 'msg2'],
+      intervalMs: 100,
+    });
+
+    onProgress('prose', 'start');
+    expect(spinner.text).toBe('msg1');
+
+    vi.advanceTimersByTime(100);
+    expect(spinner.text).toBe('msg2');
+  });
+
+  it('stops rotator on long-running phase complete', () => {
+    const spinner = createMockSpinner();
+    const { onProgress } = createPipelineProgress({
+      spinner: spinner as unknown as ReturnType<typeof createSpinner>,
+      progressMessages: ['msg1', 'msg2'],
+      intervalMs: 100,
+    });
+
+    onProgress('prose', 'start');
+    onProgress('prose', 'complete');
+
+    const textAfterComplete = spinner.text;
+    vi.advanceTimersByTime(100);
+    expect(spinner.text).toBe(textAfterComplete);
+  });
+
+  it('onThinking updates spinner when rotator is not active', () => {
+    const spinner = createMockSpinner();
+    const { onThinking } = createPipelineProgress({
+      spinner: spinner as unknown as ReturnType<typeof createSpinner>,
+      progressMessages: ['msg1'],
+    });
+
+    onThinking('thinking message');
+    expect(spinner.text).toBe('thinking message');
+  });
+
+  it('onThinking is suppressed when rotator is active', () => {
+    const spinner = createMockSpinner();
+    const { onProgress, onThinking } = createPipelineProgress({
+      spinner: spinner as unknown as ReturnType<typeof createSpinner>,
+      progressMessages: ['rotator msg'],
+    });
+
+    onProgress('prose', 'start');
+    expect(spinner.text).toBe('rotator msg');
+
+    onThinking('thinking message');
+    expect(spinner.text).toBe('rotator msg');
+  });
+
+  it('does not start rotator for non-long-running phases', () => {
+    const spinner = createMockSpinner();
+    const { onProgress, onThinking } = createPipelineProgress({
+      spinner: spinner as unknown as ReturnType<typeof createSpinner>,
+      progressMessages: ['msg1'],
+    });
+
+    onProgress('render', 'start');
+    onThinking('thinking allowed');
+    expect(spinner.text).toBe('thinking allowed');
+  });
+
+  it('uses custom majorPhases and longRunningPhases', () => {
+    const spinner = createMockSpinner();
+    const { onProgress } = createPipelineProgress({
+      spinner: spinner as unknown as ReturnType<typeof createSpinner>,
+      progressMessages: ['msg1'],
+      majorPhases: ['custom'],
+      longRunningPhases: [],
+    });
+
+    onProgress('custom', 'complete');
+    expect(spinner.succeed).toHaveBeenCalledWith('custom ✓');
+
+    onProgress('prose', 'complete');
+    expect(spinner.succeed).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `createPipelineProgress` function to `src/cli/output/progress.ts` that encapsulates spinner + rotator coordination
- Reduces ~30 lines of duplicated code to ~5 lines at each call site
- Refactors `create.ts` and `resume.ts` (2 cases) to use the new abstraction

## Changes

| File | Change |
|------|--------|
| `src/cli/output/progress.ts` | Added `createPipelineProgress` function + types |
| `src/cli/output/progress.test.ts` | Added 9 tests for new function |
| `src/cli/commands/create.ts` | Replaced inline progress handling |
| `src/cli/commands/resume.ts` | Replaced 2 duplicated blocks |

## Test plan

- [x] All 209 tests pass
- [x] TypeScript compiles without errors
- [ ] Manual test: `npm run dev create` works as before
- [ ] Manual test: `npm run dev resume` works as before

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)