### PR TITLE
fix: Rename blurb to plot for naming consistency

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -296,7 +296,7 @@ Agents are named after their output for clarity.
 | `interpreterAgent` | `string` + `Partial<StoryBrief>` | `Partial<StoryBrief>` | Parse user message into brief fields |
 | `conversationAgent` | `Partial<StoryBrief>` + `Message[]` | `ConversationResponse` | Guide story intake conversation |
 | `plotAgent` | `StoryBrief` | `PlotStructure` | Generate plot beats from brief |
-| `plotConversationAgent` | `StoryWithPlot` + `BlurbMessage[]` | `PlotConversationResponse` | Guide plot refinement |
+| `plotConversationAgent` | `StoryWithPlot` + `PlotMessage[]` | `PlotConversationResponse` | Guide plot refinement |
 | `plotInterpreterAgent` | `string` + `StoryWithPlot` | `PlotStructure` | Parse feedback into plot updates |
 
 ### Batch Agents (used by CLI commands)

--- a/docs/plans/plan-testing-infrastructure.md
+++ b/docs/plans/plan-testing-infrastructure.md
@@ -46,7 +46,7 @@ src/
 tests/
 └── fixtures/                     # Shared test data only
     ├── brief.json
-    ├── blurb.json
+    ├── plot.json
     └── manuscript.json
 ```
 

--- a/src/cli/commands/create.ts
+++ b/src/cli/commands/create.ts
@@ -36,7 +36,7 @@ export const createCommand = new Command('create')
 
       // Step 2: Get StoryWithPlot via plot iteration
       const storyWithPlot = await runPlotIntake(brief);
-      await outputManager.saveBlurb(storyWithPlot);
+      await outputManager.savePlot(storyWithPlot);
 
       // Step 3: Generate witty progress messages for prose/visuals phases
       spinner.start('Preparing witty progress messages...');

--- a/src/cli/commands/resume.ts
+++ b/src/cli/commands/resume.ts
@@ -19,7 +19,7 @@ import { runPlotIntake } from '../prompts/plot-intake';
 
 const OUTPUT_DIR = './output';
 
-type ResumeStage = 'brief' | 'blurb' | 'prose' | 'story' | 'complete';
+type ResumeStage = 'brief' | 'plot' | 'prose' | 'story' | 'complete';
 
 interface StoryFolderInfo {
   folder: string;
@@ -72,8 +72,8 @@ const detectStage = async (folder: string): Promise<StoryFolderInfo> => {
   if (files.includes('prose.json')) {
     return { folder, stage: 'prose', latestFile: path.join(folder, 'prose.json') };
   }
-  if (files.includes('blurb.json')) {
-    return { folder, stage: 'blurb', latestFile: path.join(folder, 'blurb.json') };
+  if (files.includes('plot.json')) {
+    return { folder, stage: 'plot', latestFile: path.join(folder, 'plot.json') };
   }
   if (files.includes('brief.json')) {
     return { folder, stage: 'brief', latestFile: path.join(folder, 'brief.json') };
@@ -162,8 +162,8 @@ export const resumeCommand = new Command('resume')
           break;
         }
 
-        case 'blurb': {
-          console.log('\n📍 Resuming from: blurb.json (prose + visuals + rendering)');
+        case 'plot': {
+          console.log('\n📍 Resuming from: plot.json (prose + visuals + rendering)');
           const storyWithPlot = StoryWithPlotSchema.parse(await loadJson(info.latestFile));
 
           // Generate progress messages
@@ -193,7 +193,7 @@ export const resumeCommand = new Command('resume')
           const brief = StoryBriefSchema.parse(await loadJson(info.latestFile));
 
           const storyWithPlot = await runPlotIntake(brief);
-          await outputManager.saveBlurb(storyWithPlot);
+          await outputManager.savePlot(storyWithPlot);
 
           // Generate progress messages
           spinner.start('Preparing progress messages...');

--- a/src/cli/commands/write.ts
+++ b/src/cli/commands/write.ts
@@ -17,7 +17,7 @@ const displayProse = (prose: Prose): void => {
 
 export const writeCommand = new Command('write')
   .description('Write prose from a StoryWithPlot')
-  .argument('<story-file>', 'Path to StoryWithPlot JSON file (blurb.json)')
+  .argument('<story-file>', 'Path to StoryWithPlot JSON file (plot.json)')
   .option('-o, --output <path>', 'Output file path for JSON')
   .action(async (storyFile: string, options: { output?: string }) => {
     const spinner = createSpinner();

--- a/src/cli/prompts/plot-intake.ts
+++ b/src/cli/prompts/plot-intake.ts
@@ -4,7 +4,7 @@ import type { StoryBrief, StoryWithPlot } from '../../core/schemas';
 import { plotAgent } from '../../core/agents/plot';
 import {
   plotConversationAgent,
-  type BlurbMessage,
+  type PlotMessage,
 } from '../../core/agents/plot-conversation';
 import { plotInterpreterAgent } from '../../core/agents/plot-interpreter';
 
@@ -27,7 +27,7 @@ export async function runPlotIntake(brief: StoryBrief): Promise<StoryWithPlot> {
   // Step 2: Compose StoryWithPlot
   let currentStory: StoryWithPlot = { ...brief, plot };
 
-  const history: BlurbMessage[] = [];
+  const history: PlotMessage[] = [];
 
   // Step 3: Iterate until approved
   while (true) {

--- a/src/cli/utils/output.test.ts
+++ b/src/cli/utils/output.test.ts
@@ -52,15 +52,15 @@ describe('createOutputManager', () => {
     );
   });
 
-  it('saveBlurb writes to blurb.json', async () => {
+  it('savePlot writes to plot.json', async () => {
     const manager = await createOutputManager('Test Story');
-    const blurb = { brief: {} } as any;
+    const plot = { brief: {} } as any;
 
-    await manager.saveBlurb(blurb);
+    await manager.savePlot(plot);
 
     expect(mockedFs.writeFile).toHaveBeenCalledWith(
-      'output/test-story-20241126-143052/blurb.json',
-      JSON.stringify(blurb, null, 2)
+      'output/test-story-20241126-143052/plot.json',
+      JSON.stringify(plot, null, 2)
     );
   });
 
@@ -134,10 +134,10 @@ describe('loadOutputManager', () => {
     ).rejects.toThrow('Not a valid story folder');
   });
 
-  it('accepts folder with blurb.json', async () => {
-    mockedFs.readdir.mockResolvedValue(['blurb.json'] as any);
+  it('accepts folder with plot.json', async () => {
+    mockedFs.readdir.mockResolvedValue(['plot.json'] as any);
 
-    const manager = await loadOutputManager('/path/blurb.json');
+    const manager = await loadOutputManager('/path/plot.json');
     expect(manager.folder).toBe('/path');
   });
 

--- a/src/cli/utils/output.ts
+++ b/src/cli/utils/output.ts
@@ -13,7 +13,7 @@ import { createStoryFolderName } from './naming';
 import { downloadFile } from '../../utils';
 
 const OUTPUT_DIR = './output';
-const ARTIFACT_FILES = ['brief.json', 'blurb.json', 'prose.json', 'story.json', 'book.json'];
+const ARTIFACT_FILES = ['brief.json', 'plot.json', 'prose.json', 'story.json', 'book.json'];
 
 const saveJson = (folder: string, filename: string, data: unknown): Promise<void> =>
   fs.writeFile(path.join(folder, filename), JSON.stringify(data, null, 2));
@@ -26,8 +26,8 @@ export interface StoryOutputManager {
   folder: string;
   /** Save StoryBrief to brief.json */
   saveBrief(brief: StoryBrief): Promise<void>;
-  /** Save StoryWithPlot to blurb.json (composed brief + plot) */
-  saveBlurb(story: StoryWithPlot): Promise<void>;
+  /** Save StoryWithPlot to plot.json (composed brief + plot) */
+  savePlot(story: StoryWithPlot): Promise<void>;
   /** Save StoryWithProse to prose.json (composed brief + plot + prose) */
   saveProse(story: StoryWithProse): Promise<void>;
   /** Save Story to story.json */
@@ -93,7 +93,7 @@ const slugify = (name: string): string =>
 const createManager = (folder: string): StoryOutputManager => ({
   folder,
   saveBrief: (brief) => saveJson(folder, 'brief.json', brief),
-  saveBlurb: (blurb) => saveJson(folder, 'blurb.json', blurb),
+  savePlot: (plot) => saveJson(folder, 'plot.json', plot),
   saveProse: (story) => saveJson(folder, 'prose.json', story),
   saveStory: (story) => saveJson(folder, 'story.json', story),
   saveBook: (book) => saveJson(folder, 'book.json', book),

--- a/src/core/agents/index.ts
+++ b/src/core/agents/index.ts
@@ -36,5 +36,5 @@ export { conversationAgent, type Message, type MessageRole, type ConversationAge
 
 // Plot iteration agents (PlotStructure)
 export { plotAgent } from './plot';
-export { plotConversationAgent, type BlurbMessage } from './plot-conversation';
+export { plotConversationAgent, type PlotMessage } from './plot-conversation';
 export { plotInterpreterAgent } from './plot-interpreter';

--- a/src/core/agents/plot-conversation.ts
+++ b/src/core/agents/plot-conversation.ts
@@ -29,7 +29,7 @@ APPROVAL DETECTION (isApproved field):
 - Set FALSE for any feedback requesting changes
 - When in doubt, set FALSE and ask for clarification`;
 
-export type BlurbMessage = {
+export type PlotMessage = {
   role: 'user' | 'assistant';
   content: string;
 };
@@ -41,7 +41,7 @@ export type BlurbMessage = {
  */
 export const plotConversationAgent = async (
   story: StoryWithPlot,
-  history: BlurbMessage[]
+  history: PlotMessage[]
 ): Promise<PlotConversationResponse> => {
   const storyContext = `Current Story:\n${JSON.stringify(story, null, 2)}`;
 

--- a/src/core/pipeline.test.ts
+++ b/src/core/pipeline.test.ts
@@ -217,7 +217,7 @@ describe('renderBook', () => {
     const outputManager: StoryOutputManager = {
       folder: '/test/folder',
       saveBrief: vi.fn(),
-      saveBlurb: vi.fn(),
+      savePlot: vi.fn(),
       saveProse: vi.fn(),
       saveStory: vi.fn(),
       saveBook: vi.fn(),
@@ -310,7 +310,7 @@ describe('executePipeline', () => {
     const outputManager: StoryOutputManager = {
       folder: '/test/folder',
       saveBrief: vi.fn(),
-      saveBlurb: vi.fn(),
+      savePlot: vi.fn(),
       saveProse: vi.fn(),
       saveStory: vi.fn(),
       saveBook: vi.fn(),


### PR DESCRIPTION
## Summary
- Renames `BlurbMessage` → `PlotMessage` type
- Renames `saveBlurb()` → `savePlot()` method
- Renames `blurb.json` → `plot.json` artifact file
- Updates `'blurb'` → `'plot'` stage in resume command

Aligns naming with data types (StoryWithPlot, PlotStructure) instead of UI terminology.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes (209 tests)
- [ ] Manual: Run `create` command, verify `plot.json` is created
- [ ] Manual: Run `resume` on existing story folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)