### PR TITLE
refactor: Unify create and resume with PipelineState

### DIFF
--- a/docs/plans/plan-functional-pipeline.md
+++ b/docs/plans/plan-functional-pipeline.md
@@ -1,0 +1,80 @@
+# Plan: Simple Pipeline Refactor
+
+## Goal
+Unify create and resume with a single pipeline that takes state and fills in what's missing.
+
+## Approach: PipelineState + Fill-in-the-nulls
+
+```typescript
+interface PipelineState {
+  // Foundation (at least brief required to start)
+  brief: StoryBrief;
+  plot?: PlotStructure;
+
+  // Setup artifacts
+  styleGuide?: VisualStyleGuide;
+  proseSetup?: ProseSetup;
+  characterDesigns?: CharacterDesign[];
+
+  // Content (per-page)
+  prosePages?: ProsePage[];
+  illustratedPages?: IllustratedPage[];
+
+  // Rendered
+  renderedPages?: RenderedPage[];
+  heroPage?: RenderedPage;  // first rendered page, anchors style
+}
+
+// Single entry point
+runPipelineIncremental(state: PipelineState, options?: PipelineOptions)
+  → Promise<{ story: ComposedStory; book: RenderedBook }>
+```
+
+Inside `runPipelineIncremental`:
+```typescript
+const plot = state.plot ?? await generatePlot(state.brief);
+const storyWithPlot = assembleStoryWithPlot(state.brief, plot);
+const styleGuide = state.styleGuide ?? await generateStyleGuide(storyWithPlot);
+const proseSetup = state.proseSetup ?? await generateProseSetup(storyWithPlot);
+const characterDesigns = state.characterDesigns ?? await generateCharacterDesigns(...);
+// ... etc for each stage
+```
+
+## Usage
+
+**Create command:**
+```typescript
+const state = { brief, plot };  // after intake, has brief + plot
+const { story, book } = await runPipelineIncremental(state, options);
+```
+
+**Resume command:**
+```typescript
+const state = loadPipelineState(folder);  // loads whatever exists from disk
+const { story, book } = await runPipelineIncremental(state, options);
+```
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src/core/pipeline.ts` | Add `PipelineState`, `runPipelineIncremental`, delete old functions |
+| `src/cli/commands/resume.ts` | Add `loadPipelineState`, simplify to single call |
+| `src/cli/commands/create.ts` | Call `runPipelineIncremental({ storyWithPlot })` |
+
+## Implementation Steps
+
+1. Add `PipelineState` interface
+2. Add `runPipelineIncremental` with null-coalescing for each stage
+3. Add `loadPipelineState(folder)` helper to build state from disk
+4. Update create.ts
+5. Update resume.ts
+6. Delete old `executePipeline` and `executeIncrementalPipeline`
+7. Update tests
+
+## Key Points
+
+- Single state object, single entry point
+- Each field: use if exists, generate if missing
+- `loadPipelineState` reads whatever JSONs exist and builds state
+- No type detection magic - explicit fields

--- a/src/cli/commands/create.ts
+++ b/src/cli/commands/create.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import path from 'path';
-import { executePipeline } from '../../core/pipeline';
+import { runPipelineIncremental, type PipelineState } from '../../core/pipeline';
 import { progressMessagesAgent } from '../../core/agents';
 import { runStoryIntake } from '../prompts/story-intake';
 import { runPlotIntake } from '../prompts/plot-intake';
@@ -49,7 +49,12 @@ export const createCommand = new Command('create')
         progressMessages,
       });
 
-      const { book } = await executePipeline(storyWithPlot, {
+      const pipelineState: PipelineState = {
+        brief: storyWithPlot,
+        plot: storyWithPlot.plot,
+      };
+
+      const { book } = await runPipelineIncremental(pipelineState, {
         logger,
         onProgress,
         onThinking,


### PR DESCRIPTION
## Summary
- Introduces a single `PipelineState` interface that contains all pipeline artifacts (brief, plot, styleGuide, proseSetup, characterDesigns, prosePages, illustratedPages, renderedPages, heroPage)
- Adds `runPipelineIncremental` that uses a fill-in-the-nulls pattern: pass what exists, pipeline generates what's missing
- Adds `loadPipelineState` helper in resume.ts to build state from disk
- Updates both create.ts and resume.ts to use the unified pipeline
- Deletes old `executePipeline` and `executeIncrementalPipeline` functions

## Test plan
- [x] All 210 tests pass
- [x] Typecheck passes
- [ ] Manual test: `npm run dev create` should work end-to-end
- [ ] Manual test: `npm run dev resume` should work from any stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)