### PR TITLE
refactor: Move ai.ts to services/ directory

### DIFF
--- a/src/core/agents/conversation.ts
+++ b/src/core/agents/conversation.ts
@@ -1,4 +1,4 @@
-import { generateObject } from '../utils/ai';
+import { generateObject } from '../services/ai';
 import {
   ConversationResponseSchema,
   type ConversationResponse,

--- a/src/core/agents/interpreter.ts
+++ b/src/core/agents/interpreter.ts
@@ -1,4 +1,4 @@
-import { generateObject } from '../utils/ai';
+import { generateObject } from '../services/ai';
 import { StoryBriefSchema, type StoryBrief } from '../schemas';
 import { getModel } from '../config';
 

--- a/src/core/agents/plot-conversation.ts
+++ b/src/core/agents/plot-conversation.ts
@@ -1,4 +1,4 @@
-import { generateObject } from '../utils/ai';
+import { generateObject } from '../services/ai';
 import {
   PlotConversationResponseSchema,
   type PlotConversationResponse,

--- a/src/core/agents/plot-interpreter.ts
+++ b/src/core/agents/plot-interpreter.ts
@@ -1,4 +1,4 @@
-import { generateObject } from '../utils/ai';
+import { generateObject } from '../services/ai';
 import { PlotStructureSchema, type StoryWithPlot, type PlotStructure } from '../schemas';
 import { getModel } from '../config';
 

--- a/src/core/agents/plot.ts
+++ b/src/core/agents/plot.ts
@@ -1,4 +1,4 @@
-import { generateObject } from '../utils/ai';
+import { generateObject } from '../services/ai';
 import { PlotStructureSchema, type StoryBrief, type PlotStructure } from '../schemas';
 import { getModel } from '../config';
 

--- a/src/core/agents/progress-messages.test.ts
+++ b/src/core/agents/progress-messages.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { StoryWithPlot } from '../schemas';
 
 // Mock the ai utils wrapper
-vi.mock('../utils/ai', () => ({
+vi.mock('../services/ai', () => ({
   generateObject: vi.fn(),
 }));
 
@@ -11,7 +11,7 @@ vi.mock('@ai-sdk/anthropic', () => ({
   anthropic: vi.fn(() => 'mock-model'),
 }));
 
-import { generateObject } from '../utils/ai';
+import { generateObject } from '../services/ai';
 import { progressMessagesAgent } from './progress-messages';
 
 const mockStory: StoryWithPlot = {

--- a/src/core/agents/progress-messages.ts
+++ b/src/core/agents/progress-messages.ts
@@ -4,7 +4,7 @@
  * Generates witty progress messages based on story context.
  * Used to display engaging updates during prose/visuals generation.
  */
-import { generateObject } from '../utils/ai';
+import { generateObject } from '../services/ai';
 import { anthropic } from '@ai-sdk/anthropic';
 import { z } from 'zod';
 import type { StoryWithPlot } from '../schemas';

--- a/src/core/agents/prose.ts
+++ b/src/core/agents/prose.ts
@@ -1,4 +1,4 @@
-import { generateObject, streamObjectWithProgress } from '../utils/ai';
+import { generateObject, streamObjectWithProgress } from '../services/ai';
 import {
   ProseSchema,
   ProseSetupSchema,

--- a/src/core/agents/visuals.ts
+++ b/src/core/agents/visuals.ts
@@ -1,4 +1,4 @@
-import { generateObject, streamObjectWithProgress } from '../utils/ai';
+import { generateObject, streamObjectWithProgress } from '../services/ai';
 import { z } from 'zod';
 import {
   VisualDirectionSchema,

--- a/src/core/services/ai.test.ts
+++ b/src/core/services/ai.test.ts
@@ -12,12 +12,12 @@ vi.mock('ai', () => ({
 }));
 
 // Mock retry
-vi.mock('./retry', () => ({
+vi.mock('../utils/retry', () => ({
   sleep: vi.fn(),
 }));
 
 // Mock logger
-vi.mock('./logger', () => ({
+vi.mock('../utils/logger', () => ({
   logApiSuccess: vi.fn(),
   logApiError: vi.fn(),
   logRateLimit: vi.fn(),

--- a/src/core/services/ai.ts
+++ b/src/core/services/ai.ts
@@ -12,8 +12,8 @@ import {
   type GenerateObjectResult,
 } from 'ai';
 import type { JSONParseError, TypeValidationError } from '@ai-sdk/provider';
-import { sleep } from './retry';
-import { type Logger, logApiSuccess, logApiError, logRateLimit } from './logger';
+import { sleep } from '../utils/retry';
+import { type Logger, logApiSuccess, logApiError, logRateLimit } from '../utils/logger';
 
 type GenerateObjectParams = Parameters<typeof aiGenerateObject>[0];
 


### PR DESCRIPTION
## Summary
- Moves `ai.ts` from `utils/` to `services/` directory
- Updates all agent imports to use new path
- Consolidates external API wrappers in one location

Closes #34

## Test plan
- [x] All tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)