### PR TITLE
fix: Allow brief field updates during plot-intake

### DIFF
--- a/src/cli/prompts/plot-intake.ts
+++ b/src/cli/prompts/plot-intake.ts
@@ -58,10 +58,10 @@ export async function runPlotIntake(brief: StoryBrief): Promise<StoryWithPlot> {
       ? await input({ message: 'Your feedback:' })
       : answer;
 
-    // Apply changes - interpreter returns new PlotStructure
-    const updateSpinner = ora('Updating plot...').start();
-    const updatedPlot = await plotInterpreterAgent(finalAnswer, currentStory);
-    currentStory = { ...currentStory, plot: updatedPlot };
+    // Apply changes - interpreter returns partial updates
+    const updateSpinner = ora('Updating story...').start();
+    const updates = await plotInterpreterAgent(finalAnswer, currentStory);
+    currentStory = { ...currentStory, ...updates };
     updateSpinner.stop();
 
     // Update history

--- a/src/core/agents/plot-interpreter.ts
+++ b/src/core/agents/plot-interpreter.ts
@@ -1,34 +1,34 @@
 import { generateObject } from '../services/ai';
-import { PlotStructureSchema, type StoryWithPlot, type PlotStructure } from '../schemas';
+import { StoryWithPlotSchema, type StoryWithPlot } from '../schemas';
 import { getModel } from '../config';
 
-const SYSTEM_PROMPT = `Modify plot beats based on user feedback.
+const SYSTEM_PROMPT = `Apply user's requested changes to the story.
 
-Users may reference beats by number ("change beat 3") or purpose ("strengthen the climax").
+Users may:
+- Reference beats by number ("change beat 3") or purpose ("strengthen the climax")
+- Update story settings ("make it 11 pages", "change the title")
 
 Rules:
-- Maintain 4-6 beats with valid purposes: setup, conflict, rising_action, climax, resolution
-- Preserve beats the user didn't mention
-- Update storyArcSummary if the core story changes
-- If user approves, return unchanged
-
-Output only the plot fields (storyArcSummary, plotBeats, allowCreativeLiberty).`;
+- Return ONLY the fields that changed
+- For plot changes: maintain 4-6 beats with valid purposes
+- Preserve anything the user didn't mention
+- If user approves without changes, return empty object`;
 
 /**
- * PlotInterpreterAgent: Applies user's requested changes to plot beats
+ * PlotInterpreterAgent: Applies user's requested changes to story
  *
- * Takes StoryWithPlot and user feedback, outputs PlotStructure.
- * Caller merges the result: { ...story, plot: result }
+ * Takes StoryWithPlot and user feedback, outputs partial updates.
+ * Caller merges: { ...story, ...updates }
  */
 export const plotInterpreterAgent = async (
   userFeedback: string,
   story: StoryWithPlot
-): Promise<PlotStructure> => {
+): Promise<Partial<StoryWithPlot>> => {
   const contextualPrompt = `Current Story:\n${JSON.stringify(story, null, 2)}\n\nUser feedback:\n${userFeedback}`;
 
   const { object } = await generateObject({
     model: getModel(),
-    schema: PlotStructureSchema,
+    schema: StoryWithPlotSchema.partial(),
     system: SYSTEM_PROMPT,
     prompt: contextualPrompt,
   });


### PR DESCRIPTION
## Summary
- `plotInterpreterAgent` now returns `Partial<StoryWithPlot>` instead of `PlotStructure`
- Users can update any story field (pageCount, title, etc) during plot refinement
- Simple spread merge in caller: `{ ...currentStory, ...updates }`

## Problem
When user said "make it 11 pages" during plot-intake, the change was lost because the interpreter could only return plot fields.

## Test plan
- [ ] Run CLI, set 10 pages in story-intake
- [ ] During plot-intake, say "make it 11 pages"  
- [ ] Verify downstream uses 11 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)