### PR TITLE
fix: Allow 1-4 chips in plot conversation response

### DIFF
--- a/src/core/schemas/plot.ts
+++ b/src/core/schemas/plot.ts
@@ -30,7 +30,7 @@ export type PlotStructure = z.infer<typeof PlotStructureSchema>;
  */
 export const PlotConversationResponseSchema = z.object({
   message: z.string().min(1).describe('Response to the user about their story plot'),
-  chips: z.array(z.string().min(1)).min(3).max(4).describe('3-4 suggestions. Last chip must be approval like "Looks good - let\'s write it!"'),
+  chips: z.array(z.string().min(1)).min(1).max(4).describe('1-4 suggestions. Include approval chip when ready.'),
   isApproved: z.boolean().describe('True ONLY when user explicitly approves (clicks approval chip, says "yes", "approved", "looks good", "let\'s go"). NOT for "I like the suggestions" which means incorporate them.'),
 });
 


### PR DESCRIPTION
## Summary
- Relaxed `chips.min(3)` to `chips.min(1)` in `PlotConversationResponseSchema`

## Problem
When user approves the plot (clicks "Looks good - let's write it!"), the LLM returns only 1 chip. Schema required 3 minimum, causing `NoObjectGeneratedError`.

## Test plan
- [x] Typecheck passes
- [x] Tests pass
- [ ] Manual: approve plot in CLI, verify no validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)