### PR TITLE
refactor: Composable chip response pattern

### DIFF
--- a/.claude/skills/design-agent/references/prompting-guide.md
+++ b/.claude/skills/design-agent/references/prompting-guide.md
@@ -139,10 +139,10 @@ Guidelines by [context variable]:
 ### 3. Conditional Logic in Prompts
 ```
 // Bad - hardcoding decisions
-"If the user mentions approval words like 'yes', 'okay', 'looks good', set isApproved to true."
+"If the user mentions approval words like 'yes', 'okay', 'looks good', set isComplete to true."
 
 // Good - let model understand intent
-"Set isApproved=true when the user approves the current state."
+"Set isComplete=true when the user approves the current state."
 ```
 
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -331,7 +331,7 @@ ConversationResponse {
 PlotConversationResponse {
     message: string
     chips: string[]
-    isApproved: boolean
+    isComplete: boolean
 }
 ```
 

--- a/src/cli/prompts/plot-intake.ts
+++ b/src/cli/prompts/plot-intake.ts
@@ -35,7 +35,7 @@ export async function runPlotIntake(brief: StoryBrief): Promise<StoryWithPlot> {
     const response = await plotConversationAgent(currentStory, history);
     responseSpinner.stop();
 
-    if (response.isApproved) {
+    if (response.isComplete) {
       console.log('\nPlot approved! Moving on to writing...\n');
       return currentStory;
     }

--- a/src/core/agents/plot-conversation.ts
+++ b/src/core/agents/plot-conversation.ts
@@ -23,7 +23,7 @@ CHIPS: Generate 3-4 suggestions:
 - Reference specific beats (e.g., "Strengthen the climax", "Add tension to beat 3")
 - LAST chip must be approval: "Looks good - let's write it!"
 
-APPROVAL DETECTION (isApproved field):
+COMPLETION (isComplete field):
 - Set TRUE when user explicitly approves: clicks approval chip, says "yes", "approved", "looks good", "let's go", "perfect"
 - Set FALSE for "I like the suggestions" - this means INCORPORATE them, not approve
 - Set FALSE for any feedback requesting changes

--- a/src/core/schemas/brief.ts
+++ b/src/core/schemas/brief.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { AgeRangeSchema, StoryCharacterSchema } from './common';
+import { withChipResponse } from '../services/ai';
 
 /**
  * Stage 1: StoryBrief - User requirements from book builder
@@ -24,10 +25,8 @@ export type StoryBrief = z.infer<typeof StoryBriefSchema>;
 /**
  * ConversationResponse: Output of conversation agent during story intake
  */
-export const ConversationResponseSchema = z.object({
+export const ConversationResponseSchema = withChipResponse(z.object({
   question: z.string().min(1).describe('The next question to ask the user'),
-  chips: z.array(z.string().min(1)).min(2).max(8).describe('2-8 short clickable suggestions'),
-  isComplete: z.boolean().describe('True when all required StoryBrief fields are filled'),
-});
+}));
 
 export type ConversationResponse = z.infer<typeof ConversationResponseSchema>;

--- a/src/core/schemas/plot.ts
+++ b/src/core/schemas/plot.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { BeatPurposeSchema, type BeatPurpose, StoryCharacterSchema } from './common';
+import { withChipResponse } from '../services/ai';
 
 /**
  * Stage 2: PlotStructure - Output of plotAgent
@@ -28,10 +29,8 @@ export type PlotStructure = z.infer<typeof PlotStructureSchema>;
 /**
  * PlotConversationResponse: Output of plotConversationAgent during plot refinement
  */
-export const PlotConversationResponseSchema = z.object({
+export const PlotConversationResponseSchema = withChipResponse(z.object({
   message: z.string().min(1).describe('Response to the user about their story plot'),
-  chips: z.array(z.string().min(1)).min(1).max(4).describe('1-4 suggestions. Include approval chip when ready.'),
-  isApproved: z.boolean().describe('True ONLY when user explicitly approves (clicks approval chip, says "yes", "approved", "looks good", "let\'s go"). NOT for "I like the suggestions" which means incorporate them.'),
-});
+}));
 
 export type PlotConversationResponse = z.infer<typeof PlotConversationResponseSchema>;

--- a/src/core/services/ai.ts
+++ b/src/core/services/ai.ts
@@ -12,8 +12,32 @@ import {
   type GenerateObjectResult,
 } from 'ai';
 import type { JSONParseError, TypeValidationError } from '@ai-sdk/provider';
+import { z, type ZodRawShape, type ZodObject } from 'zod';
 import { sleep } from '../utils/retry';
 import { type Logger, logApiSuccess, logApiError, logRateLimit } from '../utils/logger';
+
+// ============================================================================
+// Composable Chip Response Pattern
+// ============================================================================
+
+/**
+ * Prompt fragment for chip-based conversational responses.
+ * Include in agent system prompts that use withChipResponse schemas.
+ */
+export const CHIP_PROMPT = `Generate 2-8 short, clickable chip suggestions based on the conversation context.
+Set isComplete=true only when all required information has been gathered.`;
+
+/**
+ * Extends a Zod object schema with chip response fields.
+ * Use for any agent that returns conversational responses with suggestions.
+ */
+export const withChipResponse = <T extends ZodRawShape>(inner: ZodObject<T>) =>
+  inner.extend({
+    chips: z.array(z.string().min(1)).min(2).max(8)
+      .describe('2-8 short clickable suggestions for user response'),
+    isComplete: z.boolean()
+      .describe('True when conversation can end'),
+  });
 
 type GenerateObjectParams = Parameters<typeof aiGenerateObject>[0];
 


### PR DESCRIPTION
## Summary

- Adds `withChipResponse` Zod wrapper in `ai.ts` for reusable chip-based conversational schemas
- Refactors both `ConversationResponseSchema` and `PlotConversationResponseSchema` to use this pattern
- Unifies `isApproved` → `isComplete` across all conversation responses

## Changes

| File | Description |
|------|-------------|
| `src/core/services/ai.ts` | Add `withChipResponse` helper + `CHIP_PROMPT` |
| `src/core/schemas/brief.ts` | Use `withChipResponse` |
| `src/core/schemas/plot.ts` | Use `withChipResponse`, rename `isApproved` → `isComplete` |
| `src/core/agents/plot-conversation.ts` | Update prompt for `isComplete` |
| `src/cli/prompts/plot-intake.ts` | Update `isApproved` → `isComplete` |
| `docs/ARCHITECTURE.md` | Update type documentation |

## Test plan

- [x] `npm run test:run` - 207 tests pass
- [x] `npm run typecheck` - Clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)