### PR TITLE
feat: PartialStory schema with stage validators

### DIFF
--- a/src/core/schemas/index.ts
+++ b/src/core/schemas/index.ts
@@ -98,6 +98,16 @@ export {
   type Story,
 } from './composed';
 
+// Partial story (for progressive filling)
+export {
+  PartialStorySchema,
+  hasCompleteBrief,
+  hasCompletePlot,
+  hasCompleteProse,
+  hasCompleteVisuals,
+  type PartialStory,
+} from './partial';
+
 // Stage 5: Render
 export {
   RenderedPageSchema,

--- a/src/core/schemas/partial.test.ts
+++ b/src/core/schemas/partial.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PartialStorySchema,
+  hasCompleteBrief,
+  hasCompletePlot,
+  hasCompleteProse,
+  hasCompleteVisuals,
+  type PartialStory,
+} from './partial';
+
+const minimalBrief: PartialStory = {
+  title: 'Test Story',
+  storyArc: 'hero overcomes fear',
+  setting: 'magical forest',
+  ageRange: { min: 4, max: 8 },
+  pageCount: 10,
+  characters: [
+    { name: 'Hero', description: 'brave child', role: 'protagonist', traits: ['brave'], notes: [] },
+  ],
+};
+
+const withPlot: PartialStory = {
+  ...minimalBrief,
+  plot: {
+    storyArcSummary: 'Hero overcomes fear in the forest',
+    plotBeats: [
+      { purpose: 'setup', description: 'Hero enters forest' },
+      { purpose: 'conflict', description: 'Hero faces fear' },
+      { purpose: 'climax', description: 'Hero overcomes' },
+      { purpose: 'payoff', description: 'Hero returns' },
+    ],
+    allowCreativeLiberty: true,
+  },
+};
+
+describe('PartialStorySchema', () => {
+  it('accepts empty object', () => {
+    const result = PartialStorySchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts partial brief fields', () => {
+    const result = PartialStorySchema.safeParse({ title: 'Test' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts complete story', () => {
+    const result = PartialStorySchema.safeParse(withPlot);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('hasCompleteBrief', () => {
+  it('returns false for empty story', () => {
+    expect(hasCompleteBrief({})).toBe(false);
+  });
+
+  it('returns false for incomplete brief', () => {
+    expect(hasCompleteBrief({ title: 'Test' })).toBe(false);
+  });
+
+  it('returns true for complete brief', () => {
+    expect(hasCompleteBrief(minimalBrief)).toBe(true);
+  });
+
+  it('returns true when plot is also present', () => {
+    expect(hasCompleteBrief(withPlot)).toBe(true);
+  });
+});
+
+describe('hasCompletePlot', () => {
+  it('returns false for brief without plot', () => {
+    expect(hasCompletePlot(minimalBrief)).toBe(false);
+  });
+
+  it('returns true for story with plot', () => {
+    expect(hasCompletePlot(withPlot)).toBe(true);
+  });
+});
+
+describe('hasCompleteProse', () => {
+  it('returns false without prose', () => {
+    expect(hasCompleteProse(withPlot)).toBe(false);
+  });
+});
+
+describe('hasCompleteVisuals', () => {
+  it('returns false without visuals', () => {
+    expect(hasCompleteVisuals(withPlot)).toBe(false);
+  });
+});

--- a/src/core/schemas/partial.ts
+++ b/src/core/schemas/partial.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod';
+import { AgeRangeSchema, StoryCharacterSchema } from './common';
+import { PlotStructureSchema } from './plot';
+import { ProseSchema } from './prose';
+import { VisualDirectionSchema, CharacterDesignSchema } from './visuals';
+import { StoryBriefSchema } from './brief';
+import { StoryWithPlotSchema, StoryWithProseSchema, ComposedStorySchema } from './composed';
+
+/**
+ * PartialStory: All fields optional for progressive filling
+ * Used during pipeline execution where data is accumulated stage by stage.
+ */
+export const PartialStorySchema = z.object({
+  // Brief fields
+  title: z.string().optional(),
+  storyArc: z.string().optional(),
+  setting: z.string().optional(),
+  ageRange: AgeRangeSchema.optional(),
+  pageCount: z.number().optional(),
+  characters: z.array(StoryCharacterSchema).optional(),
+  tone: z.string().optional(),
+  moral: z.string().optional(),
+  interests: z.array(z.string()).optional(),
+  customInstructions: z.string().optional(),
+  stylePreset: z.string().optional(),
+
+  // Plot (filled in plot stage)
+  plot: PlotStructureSchema.optional(),
+
+  // Prose (filled in prose stage)
+  prose: ProseSchema.optional(),
+
+  // Visuals (filled in visuals stage)
+  visuals: VisualDirectionSchema.optional(),
+  characterDesigns: z.array(CharacterDesignSchema).optional(),
+});
+
+export type PartialStory = z.infer<typeof PartialStorySchema>;
+
+// ============================================================================
+// Stage Validators - Check if a stage can be skipped
+// ============================================================================
+
+/**
+ * Check if story has complete brief (can skip intake stage)
+ */
+export const hasCompleteBrief = (story: PartialStory): boolean =>
+  StoryBriefSchema.safeParse(story).success;
+
+/**
+ * Check if story has complete plot (can skip plot stage)
+ */
+export const hasCompletePlot = (story: PartialStory): boolean =>
+  StoryWithPlotSchema.safeParse(story).success;
+
+/**
+ * Check if story has complete prose (can skip prose stage)
+ */
+export const hasCompleteProse = (story: PartialStory): boolean =>
+  StoryWithProseSchema.safeParse(story).success;
+
+/**
+ * Check if story is fully composed (can skip to render)
+ */
+export const hasCompleteVisuals = (story: PartialStory): boolean =>
+  ComposedStorySchema.safeParse(story).success;


### PR DESCRIPTION
## Summary

Adds `PartialStorySchema` for progressive story filling - all fields optional, enabling stories to be built up incrementally.

## Stage Validators

```typescript
hasCompleteBrief(story)   // StoryBrief fields filled
hasCompletePlot(story)    // has brief + plot structure  
hasCompleteProse(story)   // has plot + prose content
hasCompleteVisuals(story) // has prose + visual direction
```

These enable conditional pipeline stages - skip stages that already have data, only run what's missing.

## Files

| File | Description |
|------|-------------|
| `src/core/schemas/partial.ts` | PartialStorySchema + validators |
| `src/core/schemas/partial.test.ts` | 11 tests |
| `src/core/schemas/index.ts` | Export new types |

## Test plan

- [x] `npm run test:run` - 218 tests pass (11 new)
- [x] `npm run typecheck` - Clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)